### PR TITLE
Fix package naming and make sure hub is ready to use when started

### DIFF
--- a/ranger-client/src/test/java/io/appform/ranger/client/AbstractRangerHubClientTest.java
+++ b/ranger-client/src/test/java/io/appform/ranger/client/AbstractRangerHubClientTest.java
@@ -33,7 +33,6 @@ public class AbstractRangerHubClientTest {
     public void testAbstractHubClient() {
         val testAbstractHub = RangerHubTestUtils.getTestHub();
         testAbstractHub.start();
-        RangerTestUtils.sleepUntilHubStarts(testAbstractHub.getHub());
         var node = testAbstractHub.getNode(service).orElse(null);
         Assert.assertNotNull(node);
         Assert.assertTrue(node.getHost().equalsIgnoreCase("localhost"));

--- a/ranger-core/src/main/java/io/appform/ranger/core/finder/serviceregistry/ListBasedServiceRegistry.java
+++ b/ranger-core/src/main/java/io/appform/ranger/core/finder/serviceregistry/ListBasedServiceRegistry.java
@@ -42,7 +42,7 @@ public class ListBasedServiceRegistry<T> extends ServiceRegistry<T> {
     }
 
     @Override
-    public void updateNodes(List<ServiceNode<T>> serviceNodes) {
+    public void update(List<ServiceNode<T>> serviceNodes) {
         nodes.set(ImmutableList.copyOf(serviceNodes));
     }
 }

--- a/ranger-core/src/main/java/io/appform/ranger/core/finder/serviceregistry/MapBasedServiceRegistry.java
+++ b/ranger-core/src/main/java/io/appform/ranger/core/finder/serviceregistry/MapBasedServiceRegistry.java
@@ -50,7 +50,7 @@ public class MapBasedServiceRegistry<T> extends ServiceRegistry<T> {
     }
 
     @Override
-    public void updateNodes(List<ServiceNode<T>> nodes) {
+    public void update(List<ServiceNode<T>> nodes) {
         ListMultimap<T, ServiceNode<T>> serviceNodes = ArrayListMultimap.create();
         nodes.forEach(serviceNode -> serviceNodes.put(serviceNode.getNodeData(), serviceNode));
         this.nodes.set(ImmutableListMultimap.copyOf(serviceNodes));

--- a/ranger-core/src/main/java/io/appform/ranger/core/finder/serviceregistry/ServiceRegistryUpdater.java
+++ b/ranger-core/src/main/java/io/appform/ranger/core/finder/serviceregistry/ServiceRegistryUpdater.java
@@ -32,7 +32,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
@@ -73,7 +72,7 @@ public class ServiceRegistryUpdater<T, D extends Deserializer<T>> {
             RetryerBuilder.<Boolean>newBuilder()
                     .retryIfResult(r -> null == r || !r)
                     .build()
-                    .call(() -> serviceRegistry.getInitialRefreshCompleted().get());
+                    .call(serviceRegistry::isRefreshed);
         }
         catch (Exception e) {
             Exceptions.illegalState("Could not perform initial state for service: " + serviceName, e);

--- a/ranger-core/src/main/java/io/appform/ranger/core/finderhub/ServiceFinderHub.java
+++ b/ranger-core/src/main/java/io/appform/ranger/core/finderhub/ServiceFinderHub.java
@@ -16,6 +16,7 @@
 package io.appform.ranger.core.finderhub;
 
 import com.github.rholder.retry.RetryerBuilder;
+import com.google.common.base.Stopwatch;
 import io.appform.ranger.core.finder.ServiceFinder;
 import io.appform.ranger.core.model.Service;
 import io.appform.ranger.core.model.ServiceRegistry;
@@ -23,6 +24,7 @@ import io.appform.ranger.core.signals.ExternalTriggeredSignal;
 import io.appform.ranger.core.signals.ScheduledSignal;
 import io.appform.ranger.core.signals.Signal;
 import io.appform.ranger.core.util.Exceptions;
+import java.util.concurrent.TimeUnit;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
@@ -38,6 +40,7 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import lombok.var;
 
 /**
  *
@@ -83,12 +86,14 @@ public class ServiceFinderHub<T, R extends ServiceRegistry<T>> {
     }
 
     public void start() {
+        log.info("Waiting for the service finder hub to start");
+        var stopwatch = Stopwatch.createStarted();
         monitorFuture = executorService.submit(this::monitor);
         refreshSignals.forEach(signal -> signal.registerConsumer(x -> updateAvailable()));
         startSignal.trigger();
         updateAvailable();
         waitTillHubIsReady();
-        log.info("Service finder hub started");
+        log.info("Service finder hub started in {} ms", stopwatch.elapsed(TimeUnit.MILLISECONDS));
     }
 
     public void stop() {

--- a/ranger-core/src/main/java/io/appform/ranger/core/finderhub/ServiceFinderHub.java
+++ b/ranger-core/src/main/java/io/appform/ranger/core/finderhub/ServiceFinderHub.java
@@ -40,7 +40,6 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-import lombok.var;
 
 /**
  *
@@ -87,7 +86,7 @@ public class ServiceFinderHub<T, R extends ServiceRegistry<T>> {
 
     public void start() {
         log.info("Waiting for the service finder hub to start");
-        var stopwatch = Stopwatch.createStarted();
+        val stopwatch = Stopwatch.createStarted();
         monitorFuture = executorService.submit(this::monitor);
         refreshSignals.forEach(signal -> signal.registerConsumer(x -> updateAvailable()));
         startSignal.trigger();
@@ -188,8 +187,7 @@ public class ServiceFinderHub<T, R extends ServiceRegistry<T>> {
                 RetryerBuilder.<Boolean>newBuilder()
                     .retryIfResult(r -> r == null || !r)
                     .build()
-                    .call(() -> serviceRegistry.getServiceRegistry()
-                        .getInitialRefreshCompleted().get());
+                    .call(() -> serviceRegistry.getServiceRegistry().isRefreshed());
             } catch (Exception e) {
                 Exceptions
                     .illegalState("Could not perform initial state for service: " + service.getServiceName(), e);

--- a/ranger-core/src/main/java/io/appform/ranger/core/model/ServiceRegistry.java
+++ b/ranger-core/src/main/java/io/appform/ranger/core/model/ServiceRegistry.java
@@ -15,6 +15,7 @@
  */
 package io.appform.ranger.core.model;
 
+import java.util.concurrent.atomic.AtomicBoolean;
 import lombok.Data;
 
 import java.util.List;
@@ -22,8 +23,14 @@ import java.util.List;
 @Data
 public abstract class ServiceRegistry<T> {
     private final Service service;
+    private final AtomicBoolean initialRefreshCompleted = new AtomicBoolean(false);
 
     public abstract List<ServiceNode<T>> nodeList();
 
-    public abstract void updateNodes(List<ServiceNode<T>> nodes);
+    public abstract void update(List<ServiceNode<T>> nodes);
+
+    public void updateNodes(List<ServiceNode<T>> nodes) {
+        update(nodes);
+        initialRefreshCompleted.compareAndSet(false, true);
+    }
 }

--- a/ranger-core/src/main/java/io/appform/ranger/core/model/ServiceRegistry.java
+++ b/ranger-core/src/main/java/io/appform/ranger/core/model/ServiceRegistry.java
@@ -16,21 +16,29 @@
 package io.appform.ranger.core.model;
 
 import java.util.concurrent.atomic.AtomicBoolean;
-import lombok.Data;
 
 import java.util.List;
+import lombok.Getter;
 
-@Data
 public abstract class ServiceRegistry<T> {
+    @Getter
     private final Service service;
-    private final AtomicBoolean initialRefreshCompleted = new AtomicBoolean(false);
+    private final AtomicBoolean refreshed = new AtomicBoolean(false);
+
+    protected ServiceRegistry(Service service) {
+        this.service = service;
+    }
 
     public abstract List<ServiceNode<T>> nodeList();
 
-    public abstract void update(List<ServiceNode<T>> nodes);
+    protected abstract void update(List<ServiceNode<T>> nodes);
 
     public void updateNodes(List<ServiceNode<T>> nodes) {
         update(nodes);
-        initialRefreshCompleted.compareAndSet(false, true);
+        refreshed.compareAndSet(false, true);
+    }
+
+    public boolean isRefreshed() {
+        return refreshed.get();
     }
 }

--- a/ranger-core/src/main/java/io/appform/ranger/core/model/ServiceRegistry.java
+++ b/ranger-core/src/main/java/io/appform/ranger/core/model/ServiceRegistry.java
@@ -25,13 +25,7 @@ public abstract class ServiceRegistry<T> {
     private final Service service;
     private final AtomicBoolean refreshed = new AtomicBoolean(false);
 
-    protected ServiceRegistry(Service service) {
-        this.service = service;
-    }
-
     public abstract List<ServiceNode<T>> nodeList();
-
-    protected abstract void update(List<ServiceNode<T>> nodes);
 
     public void updateNodes(List<ServiceNode<T>> nodes) {
         update(nodes);
@@ -41,4 +35,10 @@ public abstract class ServiceRegistry<T> {
     public boolean isRefreshed() {
         return refreshed.get();
     }
+
+    protected ServiceRegistry(Service service) {
+        this.service = service;
+    }
+
+    protected abstract void update(List<ServiceNode<T>> nodes);
 }

--- a/ranger-core/src/test/java/io/appform/ranger/core/utils/RangerTestUtils.java
+++ b/ranger-core/src/test/java/io/appform/ranger/core/utils/RangerTestUtils.java
@@ -16,7 +16,6 @@
 package io.appform.ranger.core.utils;
 
 import io.appform.ranger.core.finder.ServiceFinder;
-import io.appform.ranger.core.finderhub.ServiceFinderHub;
 import io.appform.ranger.core.model.Service;
 import io.appform.ranger.core.model.ServiceRegistry;
 import io.appform.ranger.core.units.TestNodeData;
@@ -75,6 +74,6 @@ public class RangerTestUtils {
         Only applicable for initial node population using finder. Works when you intend to start the finder with nodes in 'em.
      */
     public static <T, R extends ServiceRegistry<T>> void sleepUntilFinderStarts(ServiceFinder<T, R> finder){
-        await().pollDelay(Duration.ofSeconds(3)).until(() -> finder.getServiceRegistry().getInitialRefreshCompleted().get());
+        await().pollDelay(Duration.ofSeconds(3)).until(() -> finder.getServiceRegistry().isRefreshed());
     }
 }

--- a/ranger-core/src/test/java/io/appform/ranger/core/utils/RangerTestUtils.java
+++ b/ranger-core/src/test/java/io/appform/ranger/core/utils/RangerTestUtils.java
@@ -75,14 +75,6 @@ public class RangerTestUtils {
         Only applicable for initial node population using finder. Works when you intend to start the finder with nodes in 'em.
      */
     public static <T, R extends ServiceRegistry<T>> void sleepUntilFinderStarts(ServiceFinder<T, R> finder){
-        await().pollDelay(Duration.ofSeconds(3)).until(() -> !finder.getServiceRegistry().nodeList().isEmpty());
-    }
-
-    /*
-        Only applicable for initial node population using hub of finders. Works when you intend to start the finder hub with nodes in 'em.
-     */
-    public static <T, R extends ServiceRegistry<T>> void sleepUntilHubStarts(ServiceFinderHub<T, R> hub){
-        await().pollDelay(Duration.ofSeconds(3)).until(() -> hub.getServiceDataSource() != null &&
-                hub.getFinders().get().values().stream().noneMatch(finder -> finder.getServiceRegistry().nodeList().isEmpty()));
+        await().pollDelay(Duration.ofSeconds(3)).until(() -> finder.getServiceRegistry().getInitialRefreshCompleted().get());
     }
 }

--- a/ranger-http-client/src/test/java/io/appform/ranger/client/http/ShardedRangerHttpClientTest.java
+++ b/ranger-http-client/src/test/java/io/appform/ranger/client/http/ShardedRangerHttpClientTest.java
@@ -33,7 +33,6 @@ public class ShardedRangerHttpClientTest extends BaseRangerHttpClientTest {
                 .nodeRefreshTimeMs(1000)
                 .build();
         client.start();
-        RangerTestUtils.sleepUntilHubStarts(client.getHub());
         val service = RangerTestUtils.getService("test-n", "test-s");
         Assert.assertNotNull(client.getNode(service).orElse(null));
         Assert.assertNotNull(client.getNode(service, nodeData -> nodeData.getShardId() == 1).orElse(null));

--- a/ranger-http-client/src/test/java/io/appform/ranger/client/http/UnshardedRangerHttpClientTest.java
+++ b/ranger-http-client/src/test/java/io/appform/ranger/client/http/UnshardedRangerHttpClientTest.java
@@ -33,7 +33,6 @@ public class UnshardedRangerHttpClientTest extends BaseRangerHttpClientTest {
                 .nodeRefreshTimeMs(1000)
                 .build();
         client.start();
-        RangerTestUtils.sleepUntilHubStarts(client.getHub());
         val service = RangerTestUtils.getService("test-n", "test-s");
         Assert.assertNotNull(client.getNode(service).orElse(null));
         Assert.assertNotNull(client.getNode(service, nodeData -> nodeData.getShardId() == 1).orElse(null));

--- a/ranger-http-server-bundle/src/main/java/io/appform/ranger/http/server/bundle/HttpServerBundle.java
+++ b/ranger-http-server-bundle/src/main/java/io/appform/ranger/http/server/bundle/HttpServerBundle.java
@@ -25,7 +25,7 @@ import io.appform.ranger.core.finder.serviceregistry.MapBasedServiceRegistry;
 import io.appform.ranger.http.model.ServiceNodesResponse;
 import io.appform.ranger.http.server.bundle.config.RangerHttpConfiguration;
 import io.appform.ranger.http.server.bundle.healthcheck.RangerHttpHealthCheck;
-import io.appform.ranger.zk.server.bundle.RangerServerBundle;
+import io.appform.ranger.server.bundle.RangerServerBundle;
 import io.dropwizard.Configuration;
 import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/ranger-server-bundle/src/main/java/io/appform/ranger/server/bundle/RangerServerBundle.java
+++ b/ranger-server-bundle/src/main/java/io/appform/ranger/server/bundle/RangerServerBundle.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.appform.ranger.zk.server.bundle;
+package io.appform.ranger.server.bundle;
 
 import com.codahale.metrics.health.HealthCheck;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -21,10 +21,10 @@ import com.google.common.collect.ImmutableList;
 import io.appform.ranger.client.RangerHubClient;
 import io.appform.ranger.core.model.ServiceRegistry;
 import io.appform.ranger.core.signals.Signal;
-import io.appform.ranger.zk.server.bundle.resources.RangerResource;
-import io.appform.ranger.zk.server.bundle.rotation.BirTask;
-import io.appform.ranger.zk.server.bundle.rotation.OorTask;
-import io.appform.ranger.zk.server.bundle.rotation.RotationStatus;
+import io.appform.ranger.server.bundle.resources.RangerResource;
+import io.appform.ranger.server.bundle.rotation.BirTask;
+import io.appform.ranger.server.bundle.rotation.OorTask;
+import io.appform.ranger.server.bundle.rotation.RotationStatus;
 import io.dropwizard.Configuration;
 import io.dropwizard.ConfiguredBundle;
 import io.dropwizard.lifecycle.Managed;

--- a/ranger-server-bundle/src/main/java/io/appform/ranger/server/bundle/resources/RangerResource.java
+++ b/ranger-server-bundle/src/main/java/io/appform/ranger/server/bundle/resources/RangerResource.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.appform.ranger.zk.server.bundle.resources;
+package io.appform.ranger.server.bundle.resources;
 
 import com.codahale.metrics.annotation.Metered;
 import io.appform.ranger.client.RangerHubClient;

--- a/ranger-server-bundle/src/main/java/io/appform/ranger/server/bundle/rotation/BirTask.java
+++ b/ranger-server-bundle/src/main/java/io/appform/ranger/server/bundle/rotation/BirTask.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.appform.ranger.zk.server.bundle.rotation;
+package io.appform.ranger.server.bundle.rotation;
 
 import io.dropwizard.servlets.tasks.Task;
 import lombok.extern.slf4j.Slf4j;
@@ -23,18 +23,18 @@ import java.util.List;
 import java.util.Map;
 
 @Slf4j
-public class OorTask extends Task {
+public class BirTask extends Task {
 
     private final RotationStatus rotationStatus;
 
-    public OorTask(RotationStatus rotationStatus) {
-        super("ranger-oor");
+    public BirTask(RotationStatus rotationStatus) {
+        super("ranger-bir");
         this.rotationStatus = rotationStatus;
     }
 
     @Override
     public void execute(Map<String, List<String>> map, PrintWriter printWriter) {
-        rotationStatus.oor();
-        log.info("Taking node out of rotation on ranger");
+        rotationStatus.bir();
+        log.info("Taking node back into rotation on ranger");
     }
 }

--- a/ranger-server-bundle/src/main/java/io/appform/ranger/server/bundle/rotation/OorTask.java
+++ b/ranger-server-bundle/src/main/java/io/appform/ranger/server/bundle/rotation/OorTask.java
@@ -13,27 +13,28 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.appform.ranger.zk.server.bundle.healthcheck;
+package io.appform.ranger.server.bundle.rotation;
 
-import com.codahale.metrics.health.HealthCheck;
+import io.dropwizard.servlets.tasks.Task;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.curator.framework.CuratorFramework;
 
-import javax.inject.Singleton;
+import java.io.PrintWriter;
+import java.util.List;
+import java.util.Map;
 
-@Singleton
 @Slf4j
-public class RangerHealthCheck extends HealthCheck {
+public class OorTask extends Task {
 
-    private final CuratorFramework curatorFramework;
+    private final RotationStatus rotationStatus;
 
-    public RangerHealthCheck(CuratorFramework curatorFramework){
-        this.curatorFramework = curatorFramework;
+    public OorTask(RotationStatus rotationStatus) {
+        super("ranger-oor");
+        this.rotationStatus = rotationStatus;
     }
 
     @Override
-    protected Result check() {
-        return curatorFramework.getZookeeperClient().isConnected() ?
-                Result.healthy("Service is healthy") : Result.unhealthy("Can't connect to zookeeper");
+    public void execute(Map<String, List<String>> map, PrintWriter printWriter) {
+        rotationStatus.oor();
+        log.info("Taking node out of rotation on ranger");
     }
 }

--- a/ranger-server-bundle/src/main/java/io/appform/ranger/server/bundle/rotation/RotationStatus.java
+++ b/ranger-server-bundle/src/main/java/io/appform/ranger/server/bundle/rotation/RotationStatus.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.appform.ranger.zk.server.bundle.rotation;
+package io.appform.ranger.server.bundle.rotation;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 

--- a/ranger-server-bundle/src/test/java/io/appform/ranger/server/bundle/RangerServerBundleTest.java
+++ b/ranger-server-bundle/src/test/java/io/appform/ranger/server/bundle/RangerServerBundleTest.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.appform.ranger.zk.server.bundle;
+package io.appform.ranger.server.bundle;
 
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.health.HealthCheck;

--- a/ranger-server-bundle/src/test/java/io/appform/ranger/server/bundle/RangerServerBundleTest.java
+++ b/ranger-server-bundle/src/test/java/io/appform/ranger/server/bundle/RangerServerBundleTest.java
@@ -91,7 +91,6 @@ public class RangerServerBundleTest {
     public void testRangerBundle() {
         var hub = rangerServerBundle.getHubs().get(0);
         Assert.assertTrue(hub instanceof RangerTestHub);
-        RangerTestUtils.sleepUntilHubStarts(((RangerTestHub) hub).getHub());
         var node = hub.getNode(service).orElse(null);
         Assert.assertNotNull(node);
         Assert.assertTrue(node.getHost().equalsIgnoreCase("localhost"));

--- a/ranger-zk-client/src/test/java/io/appform/ranger/client/zk/ShardedZKRangerClientTest.java
+++ b/ranger-zk-client/src/test/java/io/appform/ranger/client/zk/ShardedZKRangerClientTest.java
@@ -37,7 +37,6 @@ public class ShardedZKRangerClientTest extends BaseRangerZKClientTest {
                 .nodeRefreshTimeMs(1000)
                 .build();
         zkHubClient.start();
-        RangerTestUtils.sleepUntilHubStarts(zkHubClient.getHub());
         Assert.assertNotNull(zkHubClient.getNode(RangerTestUtils.getService("test-n", "s1")).orElse(null));
         Assert.assertNotNull(zkHubClient.getNode(RangerTestUtils.getService("test-n", "s1"), nodeData -> nodeData.getShardId() == 1).orElse(null));
         zkHubClient.stop();

--- a/ranger-zk-client/src/test/java/io/appform/ranger/client/zk/UnshardedZKRangerClientTest.java
+++ b/ranger-zk-client/src/test/java/io/appform/ranger/client/zk/UnshardedZKRangerClientTest.java
@@ -37,7 +37,6 @@ public class UnshardedZKRangerClientTest extends BaseRangerZKClientTest {
                 .nodeRefreshTimeMs(1000)
                 .build();
         zkHubClient.start();
-        RangerTestUtils.sleepUntilHubStarts(zkHubClient.getHub());
         val service = RangerTestUtils.getService("test-n", "s1");
         Assert.assertNotNull(zkHubClient.getNode(service).orElse(null));
         Assert.assertNotNull(zkHubClient.getNode(service, nodeData -> nodeData.getShardId() == 1).orElse(null));

--- a/ranger-zk-server-bundle/src/main/java/io/appform/ranger/server/bundle/ZKServerBundle.java
+++ b/ranger-zk-server-bundle/src/main/java/io/appform/ranger/server/bundle/ZKServerBundle.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.appform.ranger.zk.server.bundle;
+package io.appform.ranger.server.bundle;
 
 import com.codahale.metrics.health.HealthCheck;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -25,9 +25,9 @@ import io.appform.ranger.common.server.ShardInfo;
 import io.appform.ranger.core.finder.serviceregistry.ListBasedServiceRegistry;
 import io.appform.ranger.core.model.ServiceNode;
 import io.appform.ranger.core.signals.Signal;
-import io.appform.ranger.zk.server.bundle.config.RangerConfiguration;
-import io.appform.ranger.zk.server.bundle.healthcheck.RangerHealthCheck;
-import io.appform.ranger.zk.server.bundle.lifecycle.CuratorLifecycle;
+import io.appform.ranger.server.bundle.config.RangerConfiguration;
+import io.appform.ranger.server.bundle.healthcheck.RangerHealthCheck;
+import io.appform.ranger.server.bundle.lifecycle.CuratorLifecycle;
 import io.dropwizard.Configuration;
 import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/ranger-zk-server-bundle/src/main/java/io/appform/ranger/server/bundle/config/RangerConfiguration.java
+++ b/ranger-zk-server-bundle/src/main/java/io/appform/ranger/server/bundle/config/RangerConfiguration.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.appform.ranger.zk.server.bundle.config;
+package io.appform.ranger.server.bundle.config;
 
 import io.appform.ranger.client.RangerClientConstants;
 import lombok.AllArgsConstructor;

--- a/ranger-zk-server-bundle/src/main/java/io/appform/ranger/server/bundle/healthcheck/RangerHealthCheck.java
+++ b/ranger-zk-server-bundle/src/main/java/io/appform/ranger/server/bundle/healthcheck/RangerHealthCheck.java
@@ -13,28 +13,27 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.appform.ranger.zk.server.bundle.rotation;
+package io.appform.ranger.server.bundle.healthcheck;
 
-import io.dropwizard.servlets.tasks.Task;
+import com.codahale.metrics.health.HealthCheck;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.curator.framework.CuratorFramework;
 
-import java.io.PrintWriter;
-import java.util.List;
-import java.util.Map;
+import javax.inject.Singleton;
 
+@Singleton
 @Slf4j
-public class BirTask extends Task {
+public class RangerHealthCheck extends HealthCheck {
 
-    private final RotationStatus rotationStatus;
+    private final CuratorFramework curatorFramework;
 
-    public BirTask(RotationStatus rotationStatus) {
-        super("ranger-bir");
-        this.rotationStatus = rotationStatus;
+    public RangerHealthCheck(CuratorFramework curatorFramework){
+        this.curatorFramework = curatorFramework;
     }
 
     @Override
-    public void execute(Map<String, List<String>> map, PrintWriter printWriter) {
-        rotationStatus.bir();
-        log.info("Taking node back into rotation on ranger");
+    protected Result check() {
+        return curatorFramework.getZookeeperClient().isConnected() ?
+                Result.healthy("Service is healthy") : Result.unhealthy("Can't connect to zookeeper");
     }
 }

--- a/ranger-zk-server-bundle/src/main/java/io/appform/ranger/server/bundle/lifecycle/CuratorLifecycle.java
+++ b/ranger-zk-server-bundle/src/main/java/io/appform/ranger/server/bundle/lifecycle/CuratorLifecycle.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.appform.ranger.zk.server.bundle.lifecycle;
+package io.appform.ranger.server.bundle.lifecycle;
 
 import io.appform.ranger.common.server.ShardInfo;
 import io.appform.ranger.core.signals.Signal;

--- a/ranger-zk-server/src/main/java/io/appform/ranger/zk/server/App.java
+++ b/ranger-zk-server/src/main/java/io/appform/ranger/zk/server/App.java
@@ -15,8 +15,8 @@
  */
 package io.appform.ranger.zk.server;
 
-import io.appform.ranger.zk.server.bundle.ZKServerBundle;
-import io.appform.ranger.zk.server.bundle.config.RangerConfiguration;
+import io.appform.ranger.server.bundle.ZKServerBundle;
+import io.appform.ranger.server.bundle.config.RangerConfiguration;
 import io.dropwizard.Application;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;

--- a/ranger-zk-server/src/main/java/io/appform/ranger/zk/server/AppConfiguration.java
+++ b/ranger-zk-server/src/main/java/io/appform/ranger/zk/server/AppConfiguration.java
@@ -15,7 +15,7 @@
  */
 package io.appform.ranger.zk.server;
 
-import io.appform.ranger.zk.server.bundle.config.RangerConfiguration;
+import io.appform.ranger.server.bundle.config.RangerConfiguration;
 import io.dropwizard.Configuration;
 import lombok.AllArgsConstructor;
 import lombok.Data;

--- a/ranger-zookeeper/src/test/java/io/appform/ranger/zookeeper/servicehub/ServiceHubTest.java
+++ b/ranger-zookeeper/src/test/java/io/appform/ranger/zookeeper/servicehub/ServiceHubTest.java
@@ -101,7 +101,7 @@ public class ServiceHubTest {
         provider1.start();
         refreshProviderSignal.trigger();
 
-        ExternalTriggeredSignal<Void> refreshHubSignal = new ExternalTriggeredSignal<>(() -> null, Collections.emptyList());
+        val refreshHubSignal = new ExternalTriggeredSignal<Void>(() -> null, Collections.emptyList());
         val hub = new ZkServiceFinderHubBuilder<TestNodeData, MapBasedServiceRegistry<TestNodeData>>()
             .withCuratorFramework(curatorFramework)
             .withNamespace("test")


### PR DESCRIPTION
### Package naming fix
- Root package in ranger server bundle seems to be incorrect, fixed it.
- Moved from `io.appform.ranger.zk.server.bundle` to `io.appform.ranger.server.bundle`

### Make `ServiceFinderHub` ready to use when started 
- Added a check with retryer which checks if `ServiceFinder` exists for each `Service` 
- Also checking if `initialRefreshCompleted` within each `ServiceFinder.serviceRegistry`
- Moved `initialRefreshCompleted` from `ServiceRegistryUpdater` into `ServiceRegistry` because we have multiple services being refreshed together
- Why adding the check in `ServiceFinderHub#start` rather than to `RangerServerBundle.run` or maybe as a refresher signal? Wanted to enforce this check as we would guarantee that hub is ready for use as it get started and with refresher or other choices it may go away as there can be other custom clients that can be made and replaced. 
- Why not have the check in the `ServiceFinderHub#updateRegistry` ? This is getting executed asynchronously via monitor method, need to have blocking call till everything is get's ready.