### PR TITLE
Introduction of a ServiceDataSource in RangerHubClient

### DIFF
--- a/ranger-client/src/main/java/io/appform/ranger/client/AbstractRangerClient.java
+++ b/ranger-client/src/main/java/io/appform/ranger/client/AbstractRangerClient.java
@@ -21,11 +21,10 @@ import io.appform.ranger.core.model.ServiceNode;
 import io.appform.ranger.core.model.ServiceNodeSelector;
 import io.appform.ranger.core.model.ServiceRegistry;
 import io.appform.ranger.core.model.ShardSelector;
-import lombok.experimental.SuperBuilder;
-
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Predicate;
+import lombok.experimental.SuperBuilder;
 
 @SuperBuilder
 public abstract class AbstractRangerClient<T, R extends ServiceRegistry<T>> implements RangerClient<T, R> {

--- a/ranger-client/src/main/java/io/appform/ranger/client/AbstractRangerHubClient.java
+++ b/ranger-client/src/main/java/io/appform/ranger/client/AbstractRangerHubClient.java
@@ -21,15 +21,20 @@ import io.appform.ranger.client.utils.CriteriaUtils;
 import io.appform.ranger.core.finderhub.ServiceDataSource;
 import io.appform.ranger.core.finderhub.ServiceFinderFactory;
 import io.appform.ranger.core.finderhub.ServiceFinderHub;
-import io.appform.ranger.core.finderhub.StaticDataSource;
-import io.appform.ranger.core.model.*;
-import lombok.Builder;
+import io.appform.ranger.core.model.Deserializer;
+import io.appform.ranger.core.model.Service;
+import io.appform.ranger.core.model.ServiceNode;
+import io.appform.ranger.core.model.ServiceNodeSelector;
+import io.appform.ranger.core.model.ServiceRegistry;
+import io.appform.ranger.core.model.ShardSelector;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Predicate;
 import lombok.Getter;
 import lombok.experimental.SuperBuilder;
 import lombok.extern.slf4j.Slf4j;
-
-import java.util.*;
-import java.util.function.Predicate;
 
 @Slf4j
 @Getter
@@ -43,8 +48,7 @@ public abstract class AbstractRangerHubClient<T, R extends ServiceRegistry<T>, D
     private final boolean alwaysUseInitialCriteria;
     private int nodeRefreshTimeMs;
     private ServiceFinderHub<T, R> hub;
-    @Builder.Default
-    private Set<Service> services = Collections.emptySet();
+    private ServiceDataSource serviceDataSource;
 
     @Override
     public void start() {
@@ -58,6 +62,9 @@ public abstract class AbstractRangerHubClient<T, R extends ServiceRegistry<T>, D
                      RangerClientConstants.MINIMUM_REFRESH_TIME);
         }
         this.nodeRefreshTimeMs = Math.max(RangerClientConstants.MINIMUM_REFRESH_TIME, this.nodeRefreshTimeMs);
+        if(null == this.serviceDataSource){
+            this.serviceDataSource = getDefaultDataSource();
+        }
         this.hub = buildHub();
         this.hub.start();
     }
@@ -140,15 +147,9 @@ public abstract class AbstractRangerHubClient<T, R extends ServiceRegistry<T>, D
         }
     }
 
-    protected abstract ServiceDataSource getDataSource();
+    protected abstract ServiceDataSource getDefaultDataSource();
 
-    protected ServiceDataSource buildServiceDataSource() {
-        return !services.isEmpty()
-               ? new StaticDataSource(services)
-               : getDataSource();
-    }
-
-    protected abstract ServiceFinderFactory<T, R> buildFinderFactory();
+    protected abstract ServiceFinderFactory<T, R> getFinderFactory();
 
     protected abstract ServiceFinderHub<T, R> buildHub();
 

--- a/ranger-client/src/main/java/io/appform/ranger/client/RangerClient.java
+++ b/ranger-client/src/main/java/io/appform/ranger/client/RangerClient.java
@@ -19,7 +19,6 @@ import io.appform.ranger.core.model.ServiceNode;
 import io.appform.ranger.core.model.ServiceNodeSelector;
 import io.appform.ranger.core.model.ServiceRegistry;
 import io.appform.ranger.core.model.ShardSelector;
-
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Predicate;

--- a/ranger-client/src/main/java/io/appform/ranger/client/RangerHubClient.java
+++ b/ranger-client/src/main/java/io/appform/ranger/client/RangerHubClient.java
@@ -15,8 +15,11 @@
  */
 package io.appform.ranger.client;
 
-import io.appform.ranger.core.model.*;
-
+import io.appform.ranger.core.model.Service;
+import io.appform.ranger.core.model.ServiceNode;
+import io.appform.ranger.core.model.ServiceNodeSelector;
+import io.appform.ranger.core.model.ServiceRegistry;
+import io.appform.ranger.core.model.ShardSelector;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;

--- a/ranger-client/src/main/java/io/appform/ranger/client/utils/CriteriaUtils.java
+++ b/ranger-client/src/main/java/io/appform/ranger/client/utils/CriteriaUtils.java
@@ -15,9 +15,8 @@
  */
 package io.appform.ranger.client.utils;
 
-import lombok.experimental.UtilityClass;
-
 import java.util.function.Predicate;
+import lombok.experimental.UtilityClass;
 
 @UtilityClass
 public class CriteriaUtils {

--- a/ranger-client/src/test/java/io/appform/ranger/client/AbstractRangerHubClientTest.java
+++ b/ranger-client/src/test/java/io/appform/ranger/client/AbstractRangerHubClientTest.java
@@ -43,4 +43,19 @@ public class AbstractRangerHubClientTest {
         Assert.assertFalse(testAbstractHub.getNode(RangerTestUtils.getService("test", "test"), nodeData -> nodeData.getShardId() == 1).isPresent());
         testAbstractHub.stop();
     }
+
+    @Test
+    public void testAbstractHubClientWithDataSource() {
+        val testAbstractHub = RangerHubTestUtils.getTestHubWithDataSource();
+        testAbstractHub.start();
+        var node = testAbstractHub.getNode(service).orElse(null);
+        Assert.assertNotNull(node);
+        Assert.assertTrue(node.getHost().equalsIgnoreCase("localhost"));
+        Assert.assertEquals(9200, node.getPort());
+        Assert.assertEquals(1, node.getNodeData().getShardId());
+        Assert.assertFalse(testAbstractHub.getNode(RangerTestUtils.getService("test", "test")).isPresent());
+        Assert.assertFalse(testAbstractHub.getNode(service, nodeData -> nodeData.getShardId() == 2).isPresent());
+        Assert.assertFalse(testAbstractHub.getNode(RangerTestUtils.getService("test", "test"), nodeData -> nodeData.getShardId() == 1).isPresent());
+        testAbstractHub.stop();
+    }
 }

--- a/ranger-client/src/test/java/io/appform/ranger/client/stubs/RangerTestHub.java
+++ b/ranger-client/src/test/java/io/appform/ranger/client/stubs/RangerTestHub.java
@@ -21,6 +21,7 @@ import io.appform.ranger.client.utils.RangerHubTestUtils;
 import io.appform.ranger.core.finder.serviceregistry.ListBasedServiceRegistry;
 import io.appform.ranger.core.finderhub.*;
 import io.appform.ranger.core.units.TestNodeData;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.experimental.SuperBuilder;
 
@@ -29,10 +30,8 @@ import lombok.experimental.SuperBuilder;
 public class RangerTestHub extends AbstractRangerHubClient<TestNodeData,
         ListBasedServiceRegistry<TestNodeData>, TestDeserializer<TestNodeData>> {
 
-    @Override
-    protected ServiceDataSource getDataSource() {
-        return new StaticDataSource(Sets.newHashSet(RangerHubTestUtils.service));
-    }
+    @Builder.Default
+    private final boolean useDefaultDataSource = true;
 
     @Override
     protected ServiceFinderHub<TestNodeData, ListBasedServiceRegistry<TestNodeData>> buildHub() {
@@ -46,13 +45,18 @@ public class RangerTestHub extends AbstractRangerHubClient<TestNodeData,
             protected void postBuild(ServiceFinderHub<TestNodeData, ListBasedServiceRegistry<TestNodeData>> serviceFinderHub) {
 
             }
-        }.withServiceDataSource(buildServiceDataSource())
-                .withServiceFinderFactory(buildFinderFactory())
+        }.withServiceDataSource(getServiceDataSource())
+            .withServiceFinderFactory(getFinderFactory())
                 .build();
     }
 
     @Override
-    protected ServiceFinderFactory<TestNodeData, ListBasedServiceRegistry<TestNodeData>> buildFinderFactory() {
+    protected ServiceDataSource getDefaultDataSource() {
+        return new StaticDataSource(Sets.newHashSet(RangerHubTestUtils.service));
+    }
+
+    @Override
+    protected ServiceFinderFactory<TestNodeData, ListBasedServiceRegistry<TestNodeData>> getFinderFactory() {
         return new TestServiceFinderFactory();
     }
 }

--- a/ranger-client/src/test/java/io/appform/ranger/client/utils/RangerHubTestUtils.java
+++ b/ranger-client/src/test/java/io/appform/ranger/client/utils/RangerHubTestUtils.java
@@ -16,9 +16,11 @@
 package io.appform.ranger.client.utils;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.Sets;
 import io.appform.ranger.client.stubs.RangerTestHub;
 import io.appform.ranger.client.stubs.TestCriteria;
 import io.appform.ranger.client.stubs.TestDeserializer;
+import io.appform.ranger.core.finderhub.StaticDataSource;
 import io.appform.ranger.core.model.Service;
 import io.appform.ranger.core.utils.RangerTestUtils;
 import lombok.experimental.UtilityClass;
@@ -37,6 +39,18 @@ public class RangerHubTestUtils {
                 .initialCriteria(new TestCriteria())
                 .deserializer(new TestDeserializer<>())
                 .build();
+    }
+
+    public static RangerTestHub getTestHubWithDataSource(){
+        return RangerTestHub.builder()
+            .namespace(service.getNamespace())
+            .mapper(mapper)
+            .nodeRefreshTimeMs(1000)
+            .initialCriteria(new TestCriteria())
+            .useDefaultDataSource(false)
+            .serviceDataSource(new StaticDataSource(Sets.newHashSet(RangerHubTestUtils.service)))
+            .deserializer(new TestDeserializer<>())
+            .build();
     }
 
 }

--- a/ranger-http-client/src/main/java/io/appform/ranger/client/http/ShardedRangerHttpHubClient.java
+++ b/ranger-http-client/src/main/java/io/appform/ranger/client/http/ShardedRangerHttpHubClient.java
@@ -36,37 +36,19 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @SuperBuilder
 public class ShardedRangerHttpHubClient<T>
-        extends AbstractRangerHubClient<T, MapBasedServiceRegistry<T>, HTTPResponseDataDeserializer<T>> {
+        extends AbstractRangerHttpHubClient<T, MapBasedServiceRegistry<T>, HTTPResponseDataDeserializer<T>> {
 
-    private final HttpClientConfig clientConfig;
     @Builder.Default
     private final ShardSelector<T, MapBasedServiceRegistry<T>> shardSelector = new MatchingShardSelector<>();
 
-    @Builder.Default
-    private final ServiceNodeSelector<T> nodeSelector = new RoundRobinServiceNodeSelector<>();
-
     @Override
-    protected ServiceDataSource getDataSource() {
-        return new HttpServiceDataSource<>(clientConfig, getMapper());
-    }
-
-    @Override
-    protected ServiceFinderHub<T, MapBasedServiceRegistry<T>> buildHub() {
-        return new HttpServiceFinderHubBuilder<T, MapBasedServiceRegistry<T>>()
-                .withServiceDataSource(buildServiceDataSource())
-                .withServiceFinderFactory(buildFinderFactory())
-                .withRefreshFrequencyMs(getNodeRefreshTimeMs())
-                .build();
-    }
-
-    @Override
-    protected ServiceFinderFactory<T, MapBasedServiceRegistry<T>> buildFinderFactory() {
+    protected ServiceFinderFactory<T, MapBasedServiceRegistry<T>> getFinderFactory() {
         return HttpShardedServiceFinderFactory.<T>builder()
-                .httpClientConfig(clientConfig)
+                .httpClientConfig(this.getClientConfig())
                 .nodeRefreshIntervalMs(getNodeRefreshTimeMs())
                 .deserializer(getDeserializer())
                 .shardSelector(shardSelector)
-                .nodeSelector(nodeSelector)
+                .nodeSelector(this.getNodeSelector())
                 .mapper(getMapper())
                 .build();
     }

--- a/ranger-zk-client/src/main/java/io/appform/ranger/client/zk/AbstractRangerZKHubClient.java
+++ b/ranger-zk-client/src/main/java/io/appform/ranger/client/zk/AbstractRangerZKHubClient.java
@@ -44,13 +44,13 @@ public abstract class AbstractRangerZKHubClient<T, R extends ServiceRegistry<T>,
                 .withConnectionString(connectionString)
                 .withNamespace(getNamespace())
                 .withRefreshFrequencyMs(getNodeRefreshTimeMs())
-                .withServiceDataSource(buildServiceDataSource())
-                .withServiceFinderFactory(buildFinderFactory())
+                .withServiceDataSource(getServiceDataSource())
+                .withServiceFinderFactory(getFinderFactory())
                 .build();
     }
 
     @Override
-    protected ServiceDataSource getDataSource() {
+    protected ServiceDataSource getDefaultDataSource() {
         return new ZkServiceDataSource(getNamespace(), connectionString, curatorFramework);
     }
 

--- a/ranger-zk-client/src/main/java/io/appform/ranger/client/zk/ShardedRangerZKHubClient.java
+++ b/ranger-zk-client/src/main/java/io/appform/ranger/client/zk/ShardedRangerZKHubClient.java
@@ -39,7 +39,7 @@ public class ShardedRangerZKHubClient<T>
     private final ServiceNodeSelector<T> nodeSelector = new RoundRobinServiceNodeSelector<>();
 
     @Override
-    protected ServiceFinderFactory<T, MapBasedServiceRegistry<T>> buildFinderFactory() {
+    protected ServiceFinderFactory<T, MapBasedServiceRegistry<T>> getFinderFactory() {
         return ZkShardedServiceFinderFactory.<T>builder()
                 .curatorFramework(getCuratorFramework())
                 .connectionString(getConnectionString())

--- a/ranger-zk-client/src/main/java/io/appform/ranger/client/zk/UnshardedRangerZKHubClient.java
+++ b/ranger-zk-client/src/main/java/io/appform/ranger/client/zk/UnshardedRangerZKHubClient.java
@@ -39,7 +39,7 @@ public class UnshardedRangerZKHubClient<T>
     private final ServiceNodeSelector<T> nodeSelector = new RoundRobinServiceNodeSelector<>();
 
     @Override
-    protected ServiceFinderFactory<T, ListBasedServiceRegistry<T>> buildFinderFactory() {
+    protected ServiceFinderFactory<T, ListBasedServiceRegistry<T>> getFinderFactory() {
         return ZKUnshardedServiceFinderFactory.<T>builder()
             .curatorFramework(getCuratorFramework())
             .connectionString(getConnectionString())


### PR DESCRIPTION
This is a PR addressing, https://github.com/appform-io/ranger/issues/9

This has the following changes. 

- Introduction of a ServiceDataSource in AbstractRangerHubClient, instead of the Collection<Service>, this enables users to bind their own service data source where they can define the Set of services to be polled. This will also help not fetch the entire data source when service list is empty

- This also includes an introduction of AbstractRangerHttpHubClient, from which Sharded and Unsharded Http clients are extended, instead of directly extending from AbstractRangerHuBClient, the httpHubClient holds on to the common methods like the getDefaultDataSource, like the AbstractRangerZkHubClient. 

- Added tests for the above two. 