### PR TITLE
Make round robin selection atomic

### DIFF
--- a/ranger-core/src/main/java/io/appform/ranger/core/finder/nodeselector/RoundRobinServiceNodeSelector.java
+++ b/ranger-core/src/main/java/io/appform/ranger/core/finder/nodeselector/RoundRobinServiceNodeSelector.java
@@ -26,7 +26,6 @@ public class RoundRobinServiceNodeSelector<T> implements ServiceNodeSelector<T> 
 
     @Override
     public ServiceNode<T> select(List<ServiceNode<T>> serviceNodes) {
-        index.set((index.get() + 1) % serviceNodes.size());
-        return serviceNodes.get(index.get());
+        return serviceNodes.get(index.updateAndGet(i -> (i + 1) % serviceNodes.size()));
     }
 }


### PR DESCRIPTION
Problem:
Atomic integer `index` is accessed in 3 separate places. Based on the
sequence of operations that are executed in separate threads it may
or may not give operations in round robin order.

Fix:
Use one atomic operation to get the desired functionality.

Signed-off-by: Pranith Kumar K <pranith.karampuri@phonepe.com>