### PR TITLE
Future proofing ServiceFinderHub.updateRegistry()

### DIFF
--- a/ranger-core/src/main/java/io/appform/ranger/core/finderhub/ServiceFinderHub.java
+++ b/ranger-core/src/main/java/io/appform/ranger/core/finderhub/ServiceFinderHub.java
@@ -167,6 +167,7 @@ public class ServiceFinderHub<T, R extends ServiceRegistry<T>> {
             }
             updatedFinders.putAll(newFinders);
             updatedFinders.putAll(matchingServices);
+            finders.set(updatedFinders);
         }
         catch (Exception e) {
             log.error("Error updating service list. Will maintain older list", e);
@@ -174,7 +175,6 @@ public class ServiceFinderHub<T, R extends ServiceRegistry<T>> {
         finally {
             alreadyUpdating.set(false);
         }
-        finders.set(updatedFinders);
     }
 
     private void waitTillHubIsReady() {

--- a/ranger-core/src/main/java/io/appform/ranger/core/model/ServiceRegistry.java
+++ b/ranger-core/src/main/java/io/appform/ranger/core/model/ServiceRegistry.java
@@ -29,7 +29,7 @@ public abstract class ServiceRegistry<T> {
 
     public void updateNodes(List<ServiceNode<T>> nodes) {
         update(nodes);
-        refreshed.compareAndSet(false, true);
+        refreshed.set(true);
     }
 
     public boolean isRefreshed() {


### PR DESCRIPTION
Updating of `ServiceFinderHub.finders` should be protected by
`alreadyUpdating` flag as per the code, so pushing
`finders.set(updatedFinders)` inside the try block to make sure it
happens before `alreadyUpdating.set(flase)` happens. Please note that
this won't lead to any problems at the moment as only one thread is used
to do this updating.

Also moved refreshed.compareAndSet() -> refreshed.set() as we don't need
compareAndSet() in this scenario in ServiceRegistry.

Signed-off-by: Pranith Kumar K <pranith.karampuri@phonepe.com>