### PR TITLE
Capability to dynamically add Services to ServiceDataSource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
-## [1.0-RC10]
+## [1.0-RC11]
 - Introduced a portScheme on ServiceNode, so multiple types of protocols could be supported. Was assumed to be HTTP instead. 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>io.appform.ranger</groupId>
     <artifactId>ranger</artifactId>
     <packaging>pom</packaging>
-    <version>1.0-RC10</version>
+    <version>1.0-RC11</version>
     <name>Ranger</name>
     <url>https://github.com/appform-io/ranger</url>
     <description>Service Discovery for Java</description>

--- a/ranger-client/pom.xml
+++ b/ranger-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>ranger</artifactId>
         <groupId>io.appform.ranger</groupId>
-        <version>1.0-RC10</version>
+        <version>1.0-RC11</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/ranger-client/src/main/java/io/appform/ranger/client/AbstractRangerHubClient.java
+++ b/ranger-client/src/main/java/io/appform/ranger/client/AbstractRangerHubClient.java
@@ -52,11 +52,6 @@ public abstract class AbstractRangerHubClient<T, R extends ServiceRegistry<T>, D
     private ServiceDataSource serviceDataSource;
 
     @Override
-    public CompletableFuture<?> addService(Service service) {
-        return hub.buildFinder(service);
-    }
-
-    @Override
     public void start() {
         Preconditions.checkNotNull(mapper, "Mapper can't be null");
         Preconditions.checkNotNull(namespace, "namespace can't be null");
@@ -152,6 +147,26 @@ public abstract class AbstractRangerHubClient<T, R extends ServiceRegistry<T>, D
             return Collections.emptySet();
         }
     }
+
+    /**
+     * Tries to dynamically add service for discovery.
+     * Method will return asynchronously after adding service to ServiceDataSource.
+     * To block till rangerHub is ready to discover service wait for future completion
+     *
+     * @throws UnsupportedOperationException for any datasource which doesnt support
+     *          dynamic addition of services
+     * @throws IllegalStateException if called before hub is started
+     *
+     * @return CompletableFuture which waits for hub to be ready for discovering the new service
+     */
+    @Override
+    public CompletableFuture<?> addService(Service service) {
+        if(hub == null) {
+            throw new IllegalStateException("Hub not started yet. Call .start()");
+        }
+        return hub.buildFinder(service);
+    }
+
 
     protected abstract ServiceDataSource getDefaultDataSource();
 

--- a/ranger-client/src/main/java/io/appform/ranger/client/AbstractRangerHubClient.java
+++ b/ranger-client/src/main/java/io/appform/ranger/client/AbstractRangerHubClient.java
@@ -31,6 +31,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 import java.util.function.Predicate;
 import lombok.Getter;
 import lombok.experimental.SuperBuilder;
@@ -49,6 +50,11 @@ public abstract class AbstractRangerHubClient<T, R extends ServiceRegistry<T>, D
     private int nodeRefreshTimeMs;
     private ServiceFinderHub<T, R> hub;
     private ServiceDataSource serviceDataSource;
+
+    @Override
+    public CompletableFuture<?> addService(Service service) {
+        return hub.buildFinder(service);
+    }
 
     @Override
     public void start() {

--- a/ranger-client/src/main/java/io/appform/ranger/client/RangerHubClient.java
+++ b/ranger-client/src/main/java/io/appform/ranger/client/RangerHubClient.java
@@ -23,6 +23,7 @@ import io.appform.ranger.core.model.ShardSelector;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 import java.util.function.Predicate;
 
 public interface RangerHubClient<T, R extends ServiceRegistry<T>> {
@@ -31,6 +32,8 @@ public interface RangerHubClient<T, R extends ServiceRegistry<T>> {
     void stop();
 
     Collection<Service> getRegisteredServices();
+
+    CompletableFuture addService(Service service);
 
     Optional<ServiceNode<T>> getNode(final Service service);
 

--- a/ranger-core/pom.xml
+++ b/ranger-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>ranger</artifactId>
         <groupId>io.appform.ranger</groupId>
-        <version>1.0-RC10</version>
+        <version>1.0-RC11</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/ranger-core/src/main/java/io/appform/ranger/core/finderhub/DynamicDataSource.java
+++ b/ranger-core/src/main/java/io/appform/ranger/core/finderhub/DynamicDataSource.java
@@ -1,0 +1,38 @@
+package io.appform.ranger.core.finderhub;
+
+import io.appform.ranger.core.model.Service;
+import lombok.NoArgsConstructor;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+@NoArgsConstructor
+public class DynamicDataSource implements ServiceDataSource {
+    private final Set<Service> serviceCollection = ConcurrentHashMap.newKeySet();
+
+    public DynamicDataSource(Collection<Service> initialServices) {
+        this.serviceCollection.addAll(initialServices);
+    }
+
+    @Override
+    public Collection<Service> services() {
+        return Collections.unmodifiableSet(serviceCollection);
+    }
+
+    @Override
+    public void add(Service service) {
+        this.serviceCollection.add(service);
+    }
+
+    @Override
+    public void start() {
+        // Nothing to do here
+    }
+
+    @Override
+    public void stop() {
+        // Nothing to do here
+    }
+}

--- a/ranger-core/src/main/java/io/appform/ranger/core/finderhub/ServiceDataSource.java
+++ b/ranger-core/src/main/java/io/appform/ranger/core/finderhub/ServiceDataSource.java
@@ -25,7 +25,9 @@ import java.util.Collection;
 public interface ServiceDataSource {
 
     Collection<Service> services();
-
+    default void add(Service service) {
+        throw new UnsupportedOperationException("Service addition is unsupported");
+    }
     void start();
     void stop();
 }

--- a/ranger-core/src/main/java/io/appform/ranger/core/finderhub/ServiceFinderHub.java
+++ b/ranger-core/src/main/java/io/appform/ranger/core/finderhub/ServiceFinderHub.java
@@ -86,9 +86,9 @@ public class ServiceFinderHub<T, R extends ServiceRegistry<T>> {
         if (finder != null) {
             return CompletableFuture.completedFuture(finder);
         }
+        serviceDataSource.add(service);
         return CompletableFuture.supplyAsync(() -> {
             try {
-                serviceDataSource.add(service);
                 updateAvailable();
                 waitTillServiceIsReady(service);
                 return finders.get().get(service);

--- a/ranger-core/src/main/java/io/appform/ranger/core/finderhub/ServiceFinderHub.java
+++ b/ranger-core/src/main/java/io/appform/ranger/core/finderhub/ServiceFinderHub.java
@@ -24,15 +24,12 @@ import io.appform.ranger.core.signals.ExternalTriggeredSignal;
 import io.appform.ranger.core.signals.ScheduledSignal;
 import io.appform.ranger.core.signals.Signal;
 import io.appform.ranger.core.util.Exceptions;
-import java.util.concurrent.TimeUnit;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 
 import java.util.*;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
+import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.Condition;
@@ -47,7 +44,7 @@ import java.util.stream.Collectors;
 @Slf4j
 public class ServiceFinderHub<T, R extends ServiceRegistry<T>> {
     @Getter
-    private final AtomicReference<Map<Service, ServiceFinder<T, R>>> finders = new AtomicReference<>(new HashMap<>());
+    private final AtomicReference<Map<Service, ServiceFinder<T, R>>> finders = new AtomicReference<>(new ConcurrentHashMap<>());
     private final Lock updateLock = new ReentrantLock();
     private final Condition updateCond = updateLock.newCondition();
     private boolean updateAvailable = false;
@@ -75,13 +72,31 @@ public class ServiceFinderHub<T, R extends ServiceRegistry<T>> {
         this.serviceDataSource = serviceDataSource;
         this.finderFactory = finderFactory;
         this.refreshSignals.add(new ScheduledSignal<>("service-hub-updater",
-                                                      () -> null,
-                                                      Collections.emptyList(),
-                                                      10_000));
+                () -> null,
+                Collections.emptyList(),
+                10_000));
     }
 
     public Optional<ServiceFinder<T, R>> finder(final Service service) {
         return Optional.ofNullable(finders.get().get(service));
+    }
+
+    public CompletableFuture<ServiceFinder<T, R>> buildFinder(final Service service) {
+        val finder = finders.get().get(service);
+        if (finder != null) {
+            return CompletableFuture.completedFuture(finder);
+        }
+        return CompletableFuture.supplyAsync(() -> {
+            try {
+                serviceDataSource.add(service);
+                updateAvailable();
+                waitTillServiceIsReady(service);
+                return finders.get().get(service);
+            } catch(Exception e) {
+                log.warn("Exception whiling building finder", e);
+                throw e;
+            }
+        });
     }
 
     public void start() {
@@ -100,14 +115,12 @@ public class ServiceFinderHub<T, R extends ServiceRegistry<T>> {
         if (null != monitorFuture) {
             try {
                 monitorFuture.cancel(true);
-            }
-            catch (Exception e) {
+            } catch (Exception e) {
                 log.warn("Error stopping service finder hub monitor: {}", e.getMessage());
             }
         }
         log.info("Service finder hub stopped");
     }
-
     public void registerUpdateSignal(final Signal<Void> refreshSignal) {
         refreshSignals.add(refreshSignal);
     }
@@ -117,8 +130,7 @@ public class ServiceFinderHub<T, R extends ServiceRegistry<T>> {
             updateLock.lock();
             updateAvailable = true;
             updateCond.signalAll();
-        }
-        finally {
+        } finally {
             updateLock.unlock();
         }
     }
@@ -131,13 +143,11 @@ public class ServiceFinderHub<T, R extends ServiceRegistry<T>> {
                     updateCond.await();
                 }
                 updateRegistry();
-            }
-            catch (InterruptedException e) {
+            } catch (InterruptedException e) {
                 log.info("Updater thread interrupted");
                 Thread.currentThread().interrupt();
                 break;
-            }
-            finally {
+            } finally {
                 updateAvailable = false;
                 updateLock.unlock();
             }
@@ -168,29 +178,29 @@ public class ServiceFinderHub<T, R extends ServiceRegistry<T>> {
             updatedFinders.putAll(newFinders);
             updatedFinders.putAll(matchingServices);
             finders.set(updatedFinders);
-        }
-        catch (Exception e) {
+        } catch (Exception e) {
             log.error("Error updating service list. Will maintain older list", e);
-        }
-        finally {
+        } finally {
             alreadyUpdating.set(false);
         }
     }
 
     private void waitTillHubIsReady() {
-        serviceDataSource.services().forEach(service -> {
-            try {
-                RetryerBuilder.<Boolean>newBuilder()
+        serviceDataSource.services().forEach(this::waitTillServiceIsReady);
+    }
+
+    private void waitTillServiceIsReady(Service service) {
+        try {
+            RetryerBuilder.<Boolean>newBuilder()
                     .retryIfResult(r -> !r)
                     .build()
                     .call(() -> Optional.ofNullable(getFinders().get().get(service))
                             .map(ServiceFinder::getServiceRegistry)
                             .map(ServiceRegistry::isRefreshed)
                             .orElse(false));
-            } catch (Exception e) {
-                Exceptions
+        } catch (Exception e) {
+            Exceptions
                     .illegalState("Could not perform initial state for service: " + service.getServiceName(), e);
-            }
-        });
+        }
     }
 }

--- a/ranger-core/src/main/java/io/appform/ranger/core/finderhub/StaticDataSource.java
+++ b/ranger-core/src/main/java/io/appform/ranger/core/finderhub/StaticDataSource.java
@@ -28,7 +28,7 @@ A static data source to be used when we know the services beforehand and don't h
 
 @Slf4j
 @AllArgsConstructor
-public class StaticDataSource implements ServiceDataSource{
+public class StaticDataSource implements ServiceDataSource {
 
     private final Set<Service> services;
 

--- a/ranger-core/src/test/java/io/appform/ranger/core/finderhub/ServiceFinderHubTest.java
+++ b/ranger-core/src/test/java/io/appform/ranger/core/finderhub/ServiceFinderHubTest.java
@@ -17,8 +17,6 @@ import org.junit.Test;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Optional;
-import java.util.concurrent.CompletionException;
 
 public class ServiceFinderHubTest {
 
@@ -35,20 +33,20 @@ public class ServiceFinderHubTest {
     @Test
     public void testDynamicServiceAddition() {
         serviceFinderHub.start();
-        ServiceFinder<TestNodeData, MapBasedServiceRegistry<TestNodeData>> finder = serviceFinderHub.finder(new Service("NS", "PRE_REGISTERED_SERVICE"))
+        val preRegisteredServiceFinder = serviceFinderHub.finder(new Service("NS", "PRE_REGISTERED_SERVICE"))
                 .orElseThrow(() -> new IllegalStateException("Finder should be present"));
-        Optional<ServiceNode<TestNodeData>> node = finder.get(null, (criteria, serviceRegistry) -> serviceRegistry.nodeList());
+        val node = preRegisteredServiceFinder.get(null, (criteria, serviceRegistry) -> serviceRegistry.nodeList());
         Assert.assertTrue(node.isPresent());
         Assert.assertEquals("HOST", node.get().getHost());
         Assert.assertEquals(0, node.get().getPort());
 
         serviceFinderHub.buildFinder(new Service("NS", "SERVICE")).join();
-        finder = serviceFinderHub.finder(new Service("NS", "SERVICE"))
+        val dynamicServiceFinder = serviceFinderHub.finder(new Service("NS", "SERVICE"))
                 .orElseThrow(() -> new IllegalStateException("Finder should be present"));
-        node = finder.get(null, (criteria, serviceRegistry) -> serviceRegistry.nodeList());
-        Assert.assertTrue(node.isPresent());
-        Assert.assertEquals("HOST", node.get().getHost());
-        Assert.assertEquals(0, node.get().getPort());
+        val dynamicServiceNode = dynamicServiceFinder.get(null, (criteria, serviceRegistry) -> serviceRegistry.nodeList());
+        Assert.assertTrue(dynamicServiceNode.isPresent());
+        Assert.assertEquals("HOST", dynamicServiceNode.get().getHost());
+        Assert.assertEquals(0, dynamicServiceNode.get().getPort());
     }
 
     @Test
@@ -76,7 +74,8 @@ public class ServiceFinderHubTest {
         try {
             val future = serviceFinderHub.buildFinder(new Service("NS", "SERVICE_NAME"));
             future.join();
-        } catch (UnsupportedOperationException exception) {
+            Assert.fail("Exception should have been thrown");
+        } catch (Exception exception) {
             Assert.assertTrue("Unsupported exception should be thrown", exception instanceof UnsupportedOperationException);
         }
 

--- a/ranger-core/src/test/java/io/appform/ranger/core/finderhub/ServiceFinderHubTest.java
+++ b/ranger-core/src/test/java/io/appform/ranger/core/finderhub/ServiceFinderHubTest.java
@@ -1,0 +1,127 @@
+package io.appform.ranger.core.finderhub;
+
+
+import io.appform.ranger.core.finder.BaseServiceFinderBuilder;
+import io.appform.ranger.core.finder.ServiceFinder;
+import io.appform.ranger.core.finder.SimpleShardedServiceFinder;
+import io.appform.ranger.core.finder.serviceregistry.MapBasedServiceRegistry;
+import io.appform.ranger.core.finder.shardselector.MatchingShardSelector;
+import io.appform.ranger.core.healthcheck.HealthcheckStatus;
+import io.appform.ranger.core.model.*;
+import io.appform.ranger.core.units.TestNodeData;
+import lombok.val;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.concurrent.CompletionException;
+
+public class ServiceFinderHubTest {
+
+    private final ServiceFinderHub<TestNodeData, MapBasedServiceRegistry<TestNodeData>> serviceFinderHub = new ServiceFinderHub<>(
+            new DynamicDataSource(),
+            service ->
+                    new TestServiceFinderBuilder()
+                            .withNamespace(service.getNamespace())
+                            .withServiceName(service.getServiceName())
+                            .withDeserializer(new Deserializer<TestNodeData>() {
+                            })
+                            .build());
+
+    @Test
+    public void testDynamicServiceAddition() {
+        serviceFinderHub.start();
+        serviceFinderHub.buildFinder(new Service("NS", "SERVICE")).join();
+        val finder = serviceFinderHub.finder(new Service("NS", "SERVICE"))
+                .orElseThrow(() -> new IllegalStateException("Finder should be present"));
+        val node = finder.get(null, (criteria, serviceRegistry) -> serviceRegistry.nodeList());
+        Assert.assertTrue(node.isPresent());
+        Assert.assertEquals("HOST", node.get().getHost());
+        Assert.assertEquals(0, node.get().getPort());
+    }
+
+    @Test
+    public void testDynamicServiceAdditionAsync() throws InterruptedException {
+        serviceFinderHub.start();
+        serviceFinderHub.buildFinder(new Service("NS", "SERVICE_NAME"));
+        val finderOpt = serviceFinderHub.finder(new Service("NS", "SERVICE_NAME"));
+        Assert.assertFalse("Finders will not be availbale immediately", finderOpt.isPresent());
+        Thread.sleep(1000);
+        val finderAfterWaitOpt = serviceFinderHub.finder(new Service("NS", "SERVICE_NAME"));
+        Assert.assertTrue("Finders should be availble after some time", finderAfterWaitOpt.isPresent());
+    }
+
+
+    @Test
+    public void testDynamicServiceAdditionWithNonDynamicDataSource() {
+
+        val serviceFinderHub = new ServiceFinderHub<>(new StaticDataSource(new HashSet<>()), service -> new TestServiceFinderBuilder()
+                .withNamespace(service.getNamespace())
+                .withServiceName(service.getServiceName())
+                .withDeserializer(new Deserializer<TestNodeData>() {
+                })
+                .build());
+        serviceFinderHub.start();
+        val future = serviceFinderHub.buildFinder(new Service("NS", "SERVICE_NAME"));
+        try {
+            future.join();
+        } catch (CompletionException completionException) {
+            Assert.assertTrue("Unsupported exception should be thrown", completionException.getCause() instanceof UnsupportedOperationException);
+        }
+    }
+
+    private static class TestServiceFinderBuilder extends BaseServiceFinderBuilder<TestNodeData, MapBasedServiceRegistry<TestNodeData>, ServiceFinder<TestNodeData, MapBasedServiceRegistry<TestNodeData>>, TestServiceFinderBuilder, Deserializer<TestNodeData>> {
+
+        @Override
+        public ServiceFinder<TestNodeData, MapBasedServiceRegistry<TestNodeData>> build() {
+            val bf = buildFinder();
+            bf.start();
+            return bf;
+        }
+
+        @Override
+        protected NodeDataSource<TestNodeData, Deserializer<TestNodeData>> dataSource(Service service) {
+            return new TestNodeDataSource();
+        }
+
+        @Override
+        protected ServiceFinder<TestNodeData, MapBasedServiceRegistry<TestNodeData>> buildFinder(Service service, ShardSelector<TestNodeData, MapBasedServiceRegistry<TestNodeData>> shardSelector, ServiceNodeSelector<TestNodeData> nodeSelector) {
+            if (null == shardSelector) {
+                shardSelector = new MatchingShardSelector<>();
+            }
+            return new SimpleShardedServiceFinder<>(new MapBasedServiceRegistry<>(service), shardSelector, nodeSelector);
+
+        }
+
+        private static class TestNodeDataSource implements NodeDataSource<TestNodeData, Deserializer<TestNodeData>> {
+            @Override
+            public List<ServiceNode<TestNodeData>> refresh(Deserializer<TestNodeData> deserializer) {
+                val list = new ArrayList<ServiceNode<TestNodeData>>();
+                list.add(new ServiceNode<>("HOST", 0, TestNodeData.builder().shardId(1).build(), HealthcheckStatus.healthy, 10L, "HTTP"));
+                return list;
+            }
+
+            @Override
+            public void start() {
+
+            }
+
+            @Override
+            public void ensureConnected() {
+
+            }
+
+            @Override
+            public void stop() {
+
+            }
+
+            @Override
+            public boolean isActive() {
+                return true;
+            }
+        }
+    }
+}

--- a/ranger-http-client/pom.xml
+++ b/ranger-http-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>ranger</artifactId>
         <groupId>io.appform.ranger</groupId>
-        <version>1.0-RC10</version>
+        <version>1.0-RC11</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/ranger-http-model/pom.xml
+++ b/ranger-http-model/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>ranger</artifactId>
         <groupId>io.appform.ranger</groupId>
-        <version>1.0-RC10</version>
+        <version>1.0-RC11</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/ranger-http-server-bundle/pom.xml
+++ b/ranger-http-server-bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>ranger</artifactId>
         <groupId>io.appform.ranger</groupId>
-        <version>1.0-RC10</version>
+        <version>1.0-RC11</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/ranger-http-server/pom.xml
+++ b/ranger-http-server/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>ranger</artifactId>
         <groupId>io.appform.ranger</groupId>
-        <version>1.0-RC10</version>
+        <version>1.0-RC11</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/ranger-http/pom.xml
+++ b/ranger-http/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>ranger</artifactId>
         <groupId>io.appform.ranger</groupId>
-        <version>1.0-RC10</version>
+        <version>1.0-RC11</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/ranger-server-bundle/pom.xml
+++ b/ranger-server-bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>ranger</artifactId>
         <groupId>io.appform.ranger</groupId>
-        <version>1.0-RC10</version>
+        <version>1.0-RC11</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/ranger-server-bundle/src/main/java/io/appform/ranger/server/bundle/resources/RangerResource.java
+++ b/ranger-server-bundle/src/main/java/io/appform/ranger/server/bundle/resources/RangerResource.java
@@ -16,6 +16,7 @@
 package io.appform.ranger.server.bundle.resources;
 
 import com.codahale.metrics.annotation.Metered;
+import com.codahale.metrics.annotation.Timed;
 import io.appform.ranger.client.RangerHubClient;
 import io.appform.ranger.core.model.Service;
 import io.appform.ranger.core.model.ServiceNode;
@@ -49,7 +50,7 @@ public class RangerResource<T, R extends ServiceRegistry<T>> {
 
     @GET
     @Path("/services/v1")
-    @Metered
+    @Timed
     public GenericResponse<Set<Service>> getServices() {
         return GenericResponse.<Set<Service>>builder()
                 .data(rangerHubs.stream().map(RangerHubClient::getRegisteredServices)
@@ -59,7 +60,7 @@ public class RangerResource<T, R extends ServiceRegistry<T>> {
 
     @GET
     @Path("/nodes/v1/{namespace}/{serviceName}")
-    @Metered
+    @Timed
     public GenericResponse<List<ServiceNode<T>>> getNodes(
             @NotNull @NotEmpty @PathParam("namespace") final String namespace,
             @NotNull @NotEmpty @PathParam("serviceName") final String serviceName

--- a/ranger-server-common/pom.xml
+++ b/ranger-server-common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>ranger</artifactId>
         <groupId>io.appform.ranger</groupId>
-        <version>1.0-RC10</version>
+        <version>1.0-RC11</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/ranger-zk-client/pom.xml
+++ b/ranger-zk-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>ranger</artifactId>
         <groupId>io.appform.ranger</groupId>
-        <version>1.0-RC10</version>
+        <version>1.0-RC11</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/ranger-zk-server-bundle/pom.xml
+++ b/ranger-zk-server-bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>ranger</artifactId>
         <groupId>io.appform.ranger</groupId>
-        <version>1.0-RC10</version>
+        <version>1.0-RC11</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/ranger-zk-server/pom.xml
+++ b/ranger-zk-server/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>ranger</artifactId>
         <groupId>io.appform.ranger</groupId>
-        <version>1.0-RC10</version>
+        <version>1.0-RC11</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/ranger-zookeeper/pom.xml
+++ b/ranger-zookeeper/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>ranger</artifactId>
         <groupId>io.appform.ranger</groupId>
-        <version>1.0-RC10</version>
+        <version>1.0-RC11</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
## What?
Add `void add(Service service)` to ServiceDataSource

## Why?
RangerHub aims to be a single place to discover nodes for all services. In cases when the list of services are not known prehand, like usage of smart clients or dynamically created clients. Having capability to register service dynamically is also useful for services which cannot be known upfront.

Generally Smart clients have there own configuration management block. Service owners would have to do some wiring to make sure they merge smart client's configuration blocks with other config blocks to create rangerHub Service DataSource.
By adding these hooks, smart clients can dynamically add there service descriptors to Datasource dynamically

Addresses https://github.com/appform-io/ranger/issues/10
