### PR TITLE
Don't reset registry on refresh Failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [1.0-RC13]
+- Handling NodeDataSource refresh failures gracefully
+
 ## [1.0-RC12]
 - Dynamic service registration
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>io.appform.ranger</groupId>
     <artifactId>ranger</artifactId>
     <packaging>pom</packaging>
-    <version>1.0-RC12</version>
+    <version>1.0-RC13</version>
     <name>Ranger</name>
     <url>https://github.com/appform-io/ranger</url>
     <description>Service Discovery for Java</description>

--- a/ranger-client/pom.xml
+++ b/ranger-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>ranger</artifactId>
         <groupId>io.appform.ranger</groupId>
-        <version>1.0-RC12</version>
+        <version>1.0-RC13</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/ranger-client/src/test/java/io/appform/ranger/client/stubs/TestSimpleUnshardedServiceFinder.java
+++ b/ranger-client/src/test/java/io/appform/ranger/client/stubs/TestSimpleUnshardedServiceFinder.java
@@ -22,6 +22,7 @@ import io.appform.ranger.core.model.NodeDataSource;
 import io.appform.ranger.core.model.Service;
 import io.appform.ranger.core.model.ServiceNode;
 import io.appform.ranger.core.units.TestNodeData;
+import java.util.Optional;
 import lombok.Builder;
 
 import java.util.Collections;
@@ -44,13 +45,13 @@ public class TestSimpleUnshardedServiceFinder <T>
     static class TestDataSource implements NodeDataSource<TestNodeData, Deserializer<TestNodeData>>{
 
         @Override
-        public List<ServiceNode<TestNodeData>> refresh(Deserializer<TestNodeData> deserializer) {
-            return Collections.singletonList(
+        public Optional<List<ServiceNode<TestNodeData>>> refresh(Deserializer<TestNodeData> deserializer) {
+            return Optional.of(Collections.singletonList(
                     ServiceNode.<TestNodeData>builder()
                             .host("localhost")
                             .port(9200)
                             .nodeData(TestNodeData.builder().shardId(1).build())
-                            .build()
+                            .build())
             );
         }
 

--- a/ranger-core/pom.xml
+++ b/ranger-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>ranger</artifactId>
         <groupId>io.appform.ranger</groupId>
-        <version>1.0-RC12</version>
+        <version>1.0-RC13</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/ranger-core/src/main/java/io/appform/ranger/core/finder/serviceregistry/ServiceRegistryUpdater.java
+++ b/ranger-core/src/main/java/io/appform/ranger/core/finder/serviceregistry/ServiceRegistryUpdater.java
@@ -132,9 +132,9 @@ public class ServiceRegistryUpdater<T, D extends Deserializer<T>> {
                         serviceRegistry.getService().getServiceName());
             return;
         }
-        val nodeList = nodeDataSource.refresh(deserializer);
+        val nodeList = nodeDataSource.refresh(deserializer).orElse(null);
         if (null != nodeList) {
-            log.debug("Updating nodelist of size: {} for [{}]", nodeList.size(),
+            log.debug("Updating nodeList of size: {} for [{}]", nodeList.size(),
                          serviceRegistry.getService().getServiceName());
             serviceRegistry.updateNodes(nodeList);
         }
@@ -142,6 +142,7 @@ public class ServiceRegistryUpdater<T, D extends Deserializer<T>> {
             log.warn("Empty list returned from node data source. We are in a weird state. Keeping old list for {}",
                      serviceRegistry.getService().getServiceName());
         }
+        serviceRegistry.markAsRefreshed();
     }
 
 }

--- a/ranger-core/src/main/java/io/appform/ranger/core/finder/serviceregistry/ServiceRegistryUpdater.java
+++ b/ranger-core/src/main/java/io/appform/ranger/core/finder/serviceregistry/ServiceRegistryUpdater.java
@@ -142,7 +142,6 @@ public class ServiceRegistryUpdater<T, D extends Deserializer<T>> {
             log.warn("Empty list returned from node data source. We are in a weird state. Keeping old list for {}",
                      serviceRegistry.getService().getServiceName());
         }
-        serviceRegistry.markAsRefreshed();
     }
 
 }

--- a/ranger-core/src/main/java/io/appform/ranger/core/model/NodeDataSource.java
+++ b/ranger-core/src/main/java/io/appform/ranger/core/model/NodeDataSource.java
@@ -16,6 +16,7 @@
 package io.appform.ranger.core.model;
 
 import java.util.List;
+import java.util.Optional;
 
 /**
  *
@@ -23,7 +24,7 @@ import java.util.List;
 @SuppressWarnings("unused")
 public interface NodeDataSource<T, D extends Deserializer<T>> extends NodeDataStoreConnector<T> {
 
-    List<ServiceNode<T>> refresh(D deserializer);
+    Optional<List<ServiceNode<T>>> refresh(D deserializer);
 
     default long healthcheckZombieCheckThresholdTime(Service service) {
         return System.currentTimeMillis() - 60000; //1 Minute

--- a/ranger-core/src/main/java/io/appform/ranger/core/model/ServiceRegistry.java
+++ b/ranger-core/src/main/java/io/appform/ranger/core/model/ServiceRegistry.java
@@ -29,6 +29,9 @@ public abstract class ServiceRegistry<T> {
 
     public void updateNodes(List<ServiceNode<T>> nodes) {
         update(nodes);
+    }
+
+    public void markAsRefreshed() {
         refreshed.set(true);
     }
 

--- a/ranger-core/src/main/java/io/appform/ranger/core/model/ServiceRegistry.java
+++ b/ranger-core/src/main/java/io/appform/ranger/core/model/ServiceRegistry.java
@@ -29,9 +29,6 @@ public abstract class ServiceRegistry<T> {
 
     public void updateNodes(List<ServiceNode<T>> nodes) {
         update(nodes);
-    }
-
-    public void markAsRefreshed() {
         refreshed.set(true);
     }
 

--- a/ranger-core/src/test/java/io/appform/ranger/core/finderhub/ServiceFinderHubTest.java
+++ b/ranger-core/src/test/java/io/appform/ranger/core/finderhub/ServiceFinderHubTest.java
@@ -10,6 +10,7 @@ import io.appform.ranger.core.finder.shardselector.MatchingShardSelector;
 import io.appform.ranger.core.healthcheck.HealthcheckStatus;
 import io.appform.ranger.core.model.*;
 import io.appform.ranger.core.units.TestNodeData;
+import java.util.Optional;
 import lombok.val;
 import org.junit.Assert;
 import org.junit.Test;
@@ -106,10 +107,10 @@ public class ServiceFinderHubTest {
 
         private static class TestNodeDataSource implements NodeDataSource<TestNodeData, Deserializer<TestNodeData>> {
             @Override
-            public List<ServiceNode<TestNodeData>> refresh(Deserializer<TestNodeData> deserializer) {
+            public Optional<List<ServiceNode<TestNodeData>>> refresh(Deserializer<TestNodeData> deserializer) {
                 val list = new ArrayList<ServiceNode<TestNodeData>>();
                 list.add(new ServiceNode<>("HOST", 0, TestNodeData.builder().shardId(1).build(), HealthcheckStatus.healthy, 10L, "HTTP"));
-                return list;
+                return Optional.of(list);
             }
 
             @Override

--- a/ranger-core/src/test/java/io/appform/ranger/core/utils/RegistryTestUtils.java
+++ b/ranger-core/src/test/java/io/appform/ranger/core/utils/RegistryTestUtils.java
@@ -34,7 +34,6 @@ public class RegistryTestUtils {
                 ServiceNode.<TestNodeData>builder().host("localhost-3").port(9002).nodeData(TestNodeData.builder().shardId(3).build()).build()
         );
         serviceRegistry.updateNodes(serviceNodes);
-        serviceRegistry.markAsRefreshed();
         return serviceRegistry;
     }
 
@@ -46,7 +45,6 @@ public class RegistryTestUtils {
                 ServiceNode.<TestNodeData>builder().host("localhost-3").port(9002).nodeData(TestNodeData.builder().shardId(3).build()).build()
         );
         serviceRegistry.updateNodes(serviceNodes);
-        serviceRegistry.markAsRefreshed();
         return serviceRegistry;
     }
 }

--- a/ranger-core/src/test/java/io/appform/ranger/core/utils/RegistryTestUtils.java
+++ b/ranger-core/src/test/java/io/appform/ranger/core/utils/RegistryTestUtils.java
@@ -34,6 +34,7 @@ public class RegistryTestUtils {
                 ServiceNode.<TestNodeData>builder().host("localhost-3").port(9002).nodeData(TestNodeData.builder().shardId(3).build()).build()
         );
         serviceRegistry.updateNodes(serviceNodes);
+        serviceRegistry.markAsRefreshed();
         return serviceRegistry;
     }
 
@@ -45,6 +46,7 @@ public class RegistryTestUtils {
                 ServiceNode.<TestNodeData>builder().host("localhost-3").port(9002).nodeData(TestNodeData.builder().shardId(3).build()).build()
         );
         serviceRegistry.updateNodes(serviceNodes);
+        serviceRegistry.markAsRefreshed();
         return serviceRegistry;
     }
 }

--- a/ranger-http-client/pom.xml
+++ b/ranger-http-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>ranger</artifactId>
         <groupId>io.appform.ranger</groupId>
-        <version>1.0-RC12</version>
+        <version>1.0-RC13</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/ranger-http-model/pom.xml
+++ b/ranger-http-model/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>ranger</artifactId>
         <groupId>io.appform.ranger</groupId>
-        <version>1.0-RC12</version>
+        <version>1.0-RC13</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/ranger-http-server-bundle/pom.xml
+++ b/ranger-http-server-bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>ranger</artifactId>
         <groupId>io.appform.ranger</groupId>
-        <version>1.0-RC12</version>
+        <version>1.0-RC13</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/ranger-http-server/pom.xml
+++ b/ranger-http-server/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>ranger</artifactId>
         <groupId>io.appform.ranger</groupId>
-        <version>1.0-RC12</version>
+        <version>1.0-RC13</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/ranger-http/pom.xml
+++ b/ranger-http/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>ranger</artifactId>
         <groupId>io.appform.ranger</groupId>
-        <version>1.0-RC12</version>
+        <version>1.0-RC13</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/ranger-http/src/main/java/io/appform/ranger/http/servicefinder/HttpNodeDataSource.java
+++ b/ranger-http/src/main/java/io/appform/ranger/http/servicefinder/HttpNodeDataSource.java
@@ -24,6 +24,7 @@ import io.appform.ranger.core.util.FinderUtils;
 import io.appform.ranger.http.common.HttpNodeDataStoreConnector;
 import io.appform.ranger.http.config.HttpClientConfig;
 import io.appform.ranger.http.serde.HTTPResponseDataDeserializer;
+import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import okhttp3.HttpUrl;
@@ -50,7 +51,7 @@ public class HttpNodeDataSource<T, D extends HTTPResponseDataDeserializer<T>> ex
     }
 
     @Override
-    public List<ServiceNode<T>> refresh(D deserializer) {
+    public Optional<List<ServiceNode<T>>> refresh(D deserializer) {
         Preconditions.checkNotNull(config, "client config has not been set for node data");
         Preconditions.checkNotNull(mapper, "mapper has not been set for node data");
         val url = String.format("/ranger/nodes/v1/%s/%s", service.getNamespace(), service.getServiceName());
@@ -80,10 +81,10 @@ public class HttpNodeDataSource<T, D extends HTTPResponseDataDeserializer<T>> ex
                         val bytes = body.bytes();
                         val serviceNodesResponse = deserializer.deserialize(bytes);
                         if(serviceNodesResponse.valid()){
-                            return FinderUtils.filterValidNodes(
-                                    service,
-                                    serviceNodesResponse.getData(),
-                                    healthcheckZombieCheckThresholdTime(service));
+                            return Optional.of(FinderUtils.filterValidNodes(
+                                               service,
+                                               serviceNodesResponse.getData(),
+                                               healthcheckZombieCheckThresholdTime(service)));
                         } else{
                             log.warn("Http call to {} returned a failure response with response {}", httpUrl, serviceNodesResponse);
                         }
@@ -95,7 +96,7 @@ public class HttpNodeDataSource<T, D extends HTTPResponseDataDeserializer<T>> ex
         } catch (IOException e) {
             log.error("Error getting service data from the http endPoint: ", e);
         }
-        return null;
+        return Optional.empty();
     }
 
     @Override

--- a/ranger-http/src/main/java/io/appform/ranger/http/servicefinder/HttpNodeDataSource.java
+++ b/ranger-http/src/main/java/io/appform/ranger/http/servicefinder/HttpNodeDataSource.java
@@ -95,7 +95,7 @@ public class HttpNodeDataSource<T, D extends HTTPResponseDataDeserializer<T>> ex
         } catch (IOException e) {
             log.error("Error getting service data from the http endPoint: ", e);
         }
-        return Collections.emptyList();
+        return null;
     }
 
     @Override

--- a/ranger-server-bundle/pom.xml
+++ b/ranger-server-bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>ranger</artifactId>
         <groupId>io.appform.ranger</groupId>
-        <version>1.0-RC12</version>
+        <version>1.0-RC13</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/ranger-server-common/pom.xml
+++ b/ranger-server-common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>ranger</artifactId>
         <groupId>io.appform.ranger</groupId>
-        <version>1.0-RC12</version>
+        <version>1.0-RC13</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/ranger-zk-client/pom.xml
+++ b/ranger-zk-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>ranger</artifactId>
         <groupId>io.appform.ranger</groupId>
-        <version>1.0-RC12</version>
+        <version>1.0-RC13</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/ranger-zk-server-bundle/pom.xml
+++ b/ranger-zk-server-bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>ranger</artifactId>
         <groupId>io.appform.ranger</groupId>
-        <version>1.0-RC12</version>
+        <version>1.0-RC13</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/ranger-zk-server/pom.xml
+++ b/ranger-zk-server/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>ranger</artifactId>
         <groupId>io.appform.ranger</groupId>
-        <version>1.0-RC12</version>
+        <version>1.0-RC13</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/ranger-zookeeper/pom.xml
+++ b/ranger-zookeeper/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>ranger</artifactId>
         <groupId>io.appform.ranger</groupId>
-        <version>1.0-RC12</version>
+        <version>1.0-RC13</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/ranger-zookeeper/src/main/java/io/appform/ranger/zookeeper/servicefinder/ZkNodeDataSource.java
+++ b/ranger-zookeeper/src/main/java/io/appform/ranger/zookeeper/servicefinder/ZkNodeDataSource.java
@@ -33,6 +33,7 @@ import org.apache.zookeeper.KeeperException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import org.apache.zookeeper.KeeperException.NoNodeException;
 
 /**
  *
@@ -55,12 +56,12 @@ public class ZkNodeDataSource<T, D extends ZkNodeDataDeserializer<T>> extends Zk
         if (!isStarted()) {
             log.warn("Data source is not yet started for service: {}. No nodes will be returned.",
                      service.getServiceName());
-            return Collections.emptyList();
+            return null;
         }
         if (isStopped()) {
             log.warn("Data source is  stopped already for service: {}. No nodes will be returned.",
                      service.getServiceName());
-            return Collections.emptyList();
+            return null;
         }
         Preconditions.checkNotNull(deserializer, "Deserializer has not been set for node data");
         try {
@@ -69,7 +70,7 @@ public class ZkNodeDataSource<T, D extends ZkNodeDataDeserializer<T>> extends Zk
             if (!isActive()) {
                 log.warn("ZK connection is not active. Ignoring refresh request for service: {}",
                          service.getServiceName());
-                return Collections.emptyList();
+                return null;
             }
             val parentPath = PathBuilder.servicePath(service);
             log.debug("Looking for node list of [{}]", serviceName);
@@ -87,11 +88,14 @@ public class ZkNodeDataSource<T, D extends ZkNodeDataDeserializer<T>> extends Zk
                 }
             }
             return nodes;
+        } catch (NoNodeException e) {
+            log.info("No nodes exist for [{}]", service.getServiceName());
+            return Collections.emptyList();
         }
         catch (Exception e) {
             log.error("Error getting service data from zookeeper: ", e);
         }
-        return Collections.emptyList();
+        return null;
     }
 
     private Optional<byte[]> readChild(String parentPath, String child) throws Exception {

--- a/ranger-zookeeper/src/main/java/io/appform/ranger/zookeeper/servicefinder/ZkNodeDataSource.java
+++ b/ranger-zookeeper/src/main/java/io/appform/ranger/zookeeper/servicefinder/ZkNodeDataSource.java
@@ -48,20 +48,20 @@ public class ZkNodeDataSource<T, D extends ZkNodeDataDeserializer<T>> extends Zk
     }
 
     @Override
-    public List<ServiceNode<T>> refresh(D deserializer) {
+    public Optional<List<ServiceNode<T>>> refresh(D deserializer) {
         return checkForUpdateOnZookeeper(deserializer);
     }
 
-    private List<ServiceNode<T>> checkForUpdateOnZookeeper(D deserializer) {
+    private Optional<List<ServiceNode<T>>> checkForUpdateOnZookeeper(D deserializer) {
         if (!isStarted()) {
             log.warn("Data source is not yet started for service: {}. No nodes will be returned.",
                      service.getServiceName());
-            return null;
+            return Optional.empty();
         }
         if (isStopped()) {
             log.warn("Data source is  stopped already for service: {}. No nodes will be returned.",
                      service.getServiceName());
-            return null;
+            return Optional.empty();
         }
         Preconditions.checkNotNull(deserializer, "Deserializer has not been set for node data");
         try {
@@ -70,7 +70,7 @@ public class ZkNodeDataSource<T, D extends ZkNodeDataDeserializer<T>> extends Zk
             if (!isActive()) {
                 log.warn("ZK connection is not active. Ignoring refresh request for service: {}",
                          service.getServiceName());
-                return null;
+                return Optional.empty();
             }
             val parentPath = PathBuilder.servicePath(service);
             log.debug("Looking for node list of [{}]", serviceName);
@@ -87,15 +87,12 @@ public class ZkNodeDataSource<T, D extends ZkNodeDataDeserializer<T>> extends Zk
                     nodes.add(node);
                 }
             }
-            return nodes;
-        } catch (NoNodeException e) {
-            log.info("No nodes exist for [{}]", service.getServiceName());
-            return Collections.emptyList();
+            return Optional.of(nodes);
         }
         catch (Exception e) {
             log.error("Error getting service data from zookeeper: ", e);
         }
-        return null;
+        return Optional.empty();
     }
 
     private Optional<byte[]> readChild(String parentPath, String child) throws Exception {

--- a/ranger-zookeeper/src/main/java/io/appform/ranger/zookeeper/servicefinder/ZkNodeDataSource.java
+++ b/ranger-zookeeper/src/main/java/io/appform/ranger/zookeeper/servicefinder/ZkNodeDataSource.java
@@ -89,6 +89,12 @@ public class ZkNodeDataSource<T, D extends ZkNodeDataDeserializer<T>> extends Zk
             }
             return Optional.of(nodes);
         }
+        catch (NoNodeException e) {
+            log.error(
+                    "No ZK container node found for service: {}. Will return empty list for now. Please doublecheck service name",
+                    service.getServiceName());
+            return Optional.of(Collections.emptyList());
+        }
         catch (Exception e) {
             log.error("Error getting service data from zookeeper: ", e);
         }


### PR DESCRIPTION
On refresh failures, NodeDataSource returns empty list. But ServiceRegistryUpdater resets the list it has with this empty list leading to api failures which depend on this. It is better to not update this list and keep some potential stale nodes in the list instead when such failures occur.