### PR TITLE
Bug Fix : When the Collection of Services is empty the monitor should gracefully return

### DIFF
--- a/ranger-core/src/main/java/io/appform/ranger/core/finderhub/ServiceFinderHub.java
+++ b/ranger-core/src/main/java/io/appform/ranger/core/finderhub/ServiceFinderHub.java
@@ -163,6 +163,10 @@ public class ServiceFinderHub<T, R extends ServiceRegistry<T>> {
         final Map<Service, ServiceFinder<T, R>> updatedFinders = new HashMap<>();
         try {
             val services = serviceDataSource.services();
+            if(services.isEmpty()) {
+                log.debug("No services found for the service data source. Skipping update on the registry");
+                return;
+            }
             val knownServiceFinders = finders.get();
             val newFinders = services.stream()
                     .filter(service -> !knownServiceFinders.containsKey(service))


### PR DESCRIPTION
The [ServiceFinderHub](https://github.com/appform-io/ranger/blob/main/ranger-core/src/main/java/io/appform/ranger/core/finderhub/ServiceFinderHub.java) updateRegistry has the following problem... 

When we use a dynamic dataSource, http or zk, and when there are call failures - and the dynamicDataSources returns a list of empty services, in the above case newFinders will be empty and matchingServices.size will never match with the knownServiceFinders.size, thereby resetting the entire serviceFinders. Hence the serviceFinders end up returning empty data in case of an outage. 

The fix is to gracefully ignore the empty service list and to retain the older service list.

P.S: There is another way of tackling as well. Change the contract of the ServiceDataSource to an optional collection (informing the ones extending that it could be empty) and instead of doing an isEmpty check here, do a null check instead

Or, throw an exception from the service data sources and let the exception handling path take care of it in case of exceptions instead of doing the emptyList and checking on it. With this, true emptyLists will be preserved. But an emptyList from a service dataSource is rare and usually because of something else going on, imo! So preserving the finders in that case made more sense. (Also it isn’t styled like this in other data sinks and sources)

Can do either anyway depending on how you want it styled.  