### PR TITLE
Boundary for ServiceAddition and ServiceFinderHubRefresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [1.1-RC2]
+
+- Pertaining to PR : https://github.com/appform-io/ranger/pull/22/, building of a ServiceFinderHub and a ServiceFinder are bounded.
+
 ## [1.0-RC18]
 - Version bump to release lexicographically higher version than 1.0-dw3-RC17
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>io.appform.ranger</groupId>
     <artifactId>ranger</artifactId>
     <packaging>pom</packaging>
-    <version>1.1-RC1</version>
+    <version>1.1-RC2</version>
     <name>Ranger</name>
     <url>https://github.com/appform-io/ranger</url>
     <description>Service Discovery for Java</description>

--- a/ranger-client/pom.xml
+++ b/ranger-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>ranger</artifactId>
         <groupId>io.appform.ranger</groupId>
-        <version>1.1-RC1</version>
+        <version>1.1-RC2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/ranger-client/src/main/java/io/appform/ranger/client/AbstractRangerHubClient.java
+++ b/ranger-client/src/main/java/io/appform/ranger/client/AbstractRangerHubClient.java
@@ -18,6 +18,7 @@ package io.appform.ranger.client;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Preconditions;
 import io.appform.ranger.client.utils.CriteriaUtils;
+import io.appform.ranger.core.finder.ServiceFinder;
 import io.appform.ranger.core.finderhub.ServiceDataSource;
 import io.appform.ranger.core.finderhub.ServiceFinderFactory;
 import io.appform.ranger.core.finderhub.ServiceFinderHub;
@@ -31,7 +32,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
 import java.util.function.Predicate;
 import lombok.Getter;
 import lombok.experimental.SuperBuilder;
@@ -160,7 +160,7 @@ public abstract class AbstractRangerHubClient<T, R extends ServiceRegistry<T>, D
      * @return CompletableFuture which waits for hub to be ready for discovering the new service
      */
     @Override
-    public CompletableFuture<?> addService(Service service) {
+    public ServiceFinder<T, R> addService(Service service) {
         if(hub == null) {
             throw new IllegalStateException("Hub not started yet. Call .start()");
         }

--- a/ranger-client/src/main/java/io/appform/ranger/client/AbstractRangerHubClient.java
+++ b/ranger-client/src/main/java/io/appform/ranger/client/AbstractRangerHubClient.java
@@ -22,12 +22,8 @@ import io.appform.ranger.core.finder.ServiceFinder;
 import io.appform.ranger.core.finderhub.ServiceDataSource;
 import io.appform.ranger.core.finderhub.ServiceFinderFactory;
 import io.appform.ranger.core.finderhub.ServiceFinderHub;
-import io.appform.ranger.core.model.Deserializer;
-import io.appform.ranger.core.model.Service;
-import io.appform.ranger.core.model.ServiceNode;
-import io.appform.ranger.core.model.ServiceNodeSelector;
-import io.appform.ranger.core.model.ServiceRegistry;
-import io.appform.ranger.core.model.ShardSelector;
+import io.appform.ranger.core.model.*;
+
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -51,6 +47,8 @@ public abstract class AbstractRangerHubClient<T, R extends ServiceRegistry<T>, D
     private int nodeRefreshTimeMs;
     private ServiceFinderHub<T, R> hub;
     private ServiceDataSource serviceDataSource;
+    private long serviceRefreshDurationMs;
+    private long hubRefreshDurationMs;
 
     @Override
     public void start() {
@@ -58,12 +56,27 @@ public abstract class AbstractRangerHubClient<T, R extends ServiceRegistry<T>, D
         Preconditions.checkNotNull(namespace, "namespace can't be null");
         Preconditions.checkNotNull(deserializer, "deserializer can't be null");
 
-        if (this.nodeRefreshTimeMs < RangerClientConstants.MINIMUM_REFRESH_TIME) {
+        if (this.nodeRefreshTimeMs < HubConstants.MINIMUM_REFRESH_TIME_MS) {
             log.warn("Node info update interval too low: {} ms. Has been upgraded to {} ms ",
                      this.nodeRefreshTimeMs,
-                     RangerClientConstants.MINIMUM_REFRESH_TIME);
+                    HubConstants.MINIMUM_REFRESH_TIME_MS);
         }
-        this.nodeRefreshTimeMs = Math.max(RangerClientConstants.MINIMUM_REFRESH_TIME, this.nodeRefreshTimeMs);
+        this.nodeRefreshTimeMs = Math.max(HubConstants.MINIMUM_REFRESH_TIME_MS, this.nodeRefreshTimeMs);
+
+        if (this.serviceRefreshDurationMs <= 0) {
+            log.warn("Service Refresh interval too low: {} ms. Has been upgraded to {} ms ",
+                    this.serviceRefreshDurationMs,
+                    HubConstants.SERVICE_REFRESH_DURATION_MS);
+            this.serviceRefreshDurationMs = HubConstants.SERVICE_REFRESH_DURATION_MS;
+        }
+
+        if (this.hubRefreshDurationMs <= 0) {
+            log.warn("Service Refresh interval too low: {} ms. Has been upgraded to {} ms ",
+                    this.hubRefreshDurationMs,
+                    HubConstants.HUB_REFRESH_DURATION_MS);
+            this.hubRefreshDurationMs = HubConstants.HUB_REFRESH_DURATION_MS;
+        }
+
         if(null == this.serviceDataSource){
             this.serviceDataSource = getDefaultDataSource();
         }

--- a/ranger-client/src/main/java/io/appform/ranger/client/AbstractRangerHubClient.java
+++ b/ranger-client/src/main/java/io/appform/ranger/client/AbstractRangerHubClient.java
@@ -32,6 +32,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 import java.util.function.Predicate;
 import lombok.Getter;
 import lombok.experimental.SuperBuilder;
@@ -40,7 +41,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @Getter
 @SuperBuilder
-public abstract class AbstractRangerHubClient<T, R extends ServiceRegistry<T>, D extends Deserializer<T>> implements RangerHubClient<T, R> {
+public abstract class AbstractRangerHubClient<T, R extends ServiceRegistry<T>, D extends Deserializer<T>> implements RangerHubClient<T,R> {
 
     private final String namespace;
     private final ObjectMapper mapper;
@@ -96,7 +97,7 @@ public abstract class AbstractRangerHubClient<T, R extends ServiceRegistry<T>, D
     public Optional<ServiceNode<T>> getNode(
             final Service service,
             final Predicate<T> criteria,
-            final ShardSelector<T,R> shardSelector) {
+            final ShardSelector<T, R> shardSelector) {
         return getNode(service, criteria, shardSelector, null);
     }
 
@@ -104,7 +105,7 @@ public abstract class AbstractRangerHubClient<T, R extends ServiceRegistry<T>, D
     public Optional<ServiceNode<T>> getNode(
             final Service service,
             final Predicate<T> criteria,
-            final ShardSelector<T,R> shardSelector,
+            final ShardSelector<T, R> shardSelector,
             final ServiceNodeSelector<T> nodeSelector) {
         return this.getHub()
                 .finder(service)
@@ -160,7 +161,7 @@ public abstract class AbstractRangerHubClient<T, R extends ServiceRegistry<T>, D
      * @return CompletableFuture which waits for hub to be ready for discovering the new service
      */
     @Override
-    public ServiceFinder<T, R> addService(Service service) {
+    public CompletableFuture<?> addService(Service service) {
         if(hub == null) {
             throw new IllegalStateException("Hub not started yet. Call .start()");
         }

--- a/ranger-client/src/main/java/io/appform/ranger/client/AbstractRangerHubClient.java
+++ b/ranger-client/src/main/java/io/appform/ranger/client/AbstractRangerHubClient.java
@@ -71,7 +71,7 @@ public abstract class AbstractRangerHubClient<T, R extends ServiceRegistry<T>, D
         }
 
         if (this.hubRefreshDurationMs <= 0) {
-            log.warn("Service Refresh interval too low: {} ms. Has been upgraded to {} ms ",
+            log.warn("Hub Refresh interval too low: {} ms. Has been upgraded to {} ms ",
                     this.hubRefreshDurationMs,
                     HubConstants.HUB_REFRESH_DURATION_MS);
             this.hubRefreshDurationMs = HubConstants.HUB_REFRESH_DURATION_MS;

--- a/ranger-client/src/main/java/io/appform/ranger/client/AbstractRangerHubClient.java
+++ b/ranger-client/src/main/java/io/appform/ranger/client/AbstractRangerHubClient.java
@@ -18,7 +18,6 @@ package io.appform.ranger.client;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Preconditions;
 import io.appform.ranger.client.utils.CriteriaUtils;
-import io.appform.ranger.core.finder.ServiceFinder;
 import io.appform.ranger.core.finderhub.ServiceDataSource;
 import io.appform.ranger.core.finderhub.ServiceFinderFactory;
 import io.appform.ranger.core.finderhub.ServiceFinderHub;
@@ -110,7 +109,7 @@ public abstract class AbstractRangerHubClient<T, R extends ServiceRegistry<T>, D
     public Optional<ServiceNode<T>> getNode(
             final Service service,
             final Predicate<T> criteria,
-            final ShardSelector<T, R> shardSelector) {
+            final ShardSelector<T,R> shardSelector) {
         return getNode(service, criteria, shardSelector, null);
     }
 
@@ -118,7 +117,7 @@ public abstract class AbstractRangerHubClient<T, R extends ServiceRegistry<T>, D
     public Optional<ServiceNode<T>> getNode(
             final Service service,
             final Predicate<T> criteria,
-            final ShardSelector<T, R> shardSelector,
+            final ShardSelector<T,R> shardSelector,
             final ServiceNodeSelector<T> nodeSelector) {
         return this.getHub()
                 .finder(service)

--- a/ranger-client/src/main/java/io/appform/ranger/client/RangerHubClient.java
+++ b/ranger-client/src/main/java/io/appform/ranger/client/RangerHubClient.java
@@ -15,6 +15,7 @@
  */
 package io.appform.ranger.client;
 
+import io.appform.ranger.core.finder.ServiceFinder;
 import io.appform.ranger.core.model.Service;
 import io.appform.ranger.core.model.ServiceNode;
 import io.appform.ranger.core.model.ServiceNodeSelector;
@@ -33,7 +34,7 @@ public interface RangerHubClient<T, R extends ServiceRegistry<T>> {
 
     Collection<Service> getRegisteredServices();
 
-    CompletableFuture addService(Service service);
+    ServiceFinder<T, R> addService(Service service);
 
     Optional<ServiceNode<T>> getNode(final Service service);
 

--- a/ranger-client/src/main/java/io/appform/ranger/client/RangerHubClient.java
+++ b/ranger-client/src/main/java/io/appform/ranger/client/RangerHubClient.java
@@ -15,7 +15,6 @@
  */
 package io.appform.ranger.client;
 
-import io.appform.ranger.core.finder.ServiceFinder;
 import io.appform.ranger.core.model.Service;
 import io.appform.ranger.core.model.ServiceNode;
 import io.appform.ranger.core.model.ServiceNodeSelector;
@@ -34,7 +33,7 @@ public interface RangerHubClient<T, R extends ServiceRegistry<T>> {
 
     Collection<Service> getRegisteredServices();
 
-    CompletableFuture<?> addService(Service service);
+    CompletableFuture addService(Service service);
 
     Optional<ServiceNode<T>> getNode(final Service service);
 

--- a/ranger-client/src/main/java/io/appform/ranger/client/RangerHubClient.java
+++ b/ranger-client/src/main/java/io/appform/ranger/client/RangerHubClient.java
@@ -34,7 +34,7 @@ public interface RangerHubClient<T, R extends ServiceRegistry<T>> {
 
     Collection<Service> getRegisteredServices();
 
-    ServiceFinder<T, R> addService(Service service);
+    CompletableFuture<?> addService(Service service);
 
     Optional<ServiceNode<T>> getNode(final Service service);
 

--- a/ranger-core/pom.xml
+++ b/ranger-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>ranger</artifactId>
         <groupId>io.appform.ranger</groupId>
-        <version>1.1-RC1</version>
+        <version>1.1-RC2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/ranger-core/src/main/java/io/appform/ranger/core/finderhub/ServiceFinderHub.java
+++ b/ranger-core/src/main/java/io/appform/ranger/core/finderhub/ServiceFinderHub.java
@@ -20,6 +20,7 @@ import com.github.rholder.retry.StopStrategies;
 import com.google.common.base.Stopwatch;
 import com.google.common.base.Supplier;
 import io.appform.ranger.core.finder.ServiceFinder;
+import io.appform.ranger.core.model.HubConstants;
 import io.appform.ranger.core.model.Service;
 import io.appform.ranger.core.model.ServiceRegistry;
 import io.appform.ranger.core.signals.ExternalTriggeredSignal;
@@ -76,7 +77,7 @@ public class ServiceFinderHub<T, R extends ServiceRegistry<T>> {
             ServiceFinderFactory<T, R> finderFactory
     ) {
         this(serviceDataSource, finderFactory,
-                10_000, 30_000);
+                HubConstants.SERVICE_REFRESH_DURATION_MS, HubConstants.HUB_REFRESH_DURATION_MS);
     }
 
     public ServiceFinderHub(

--- a/ranger-core/src/main/java/io/appform/ranger/core/finderhub/ServiceFinderHub.java
+++ b/ranger-core/src/main/java/io/appform/ranger/core/finderhub/ServiceFinderHub.java
@@ -16,7 +16,9 @@
 package io.appform.ranger.core.finderhub;
 
 import com.github.rholder.retry.RetryerBuilder;
+import com.github.rholder.retry.StopStrategies;
 import com.google.common.base.Stopwatch;
+import com.google.common.base.Supplier;
 import io.appform.ranger.core.finder.ServiceFinder;
 import io.appform.ranger.core.model.Service;
 import io.appform.ranger.core.model.ServiceRegistry;
@@ -66,11 +68,26 @@ public class ServiceFinderHub<T, R extends ServiceRegistry<T>> {
     private final AtomicBoolean alreadyUpdating = new AtomicBoolean(false);
     private Future<?> monitorFuture = null;
 
+    private final long serviceRefreshDurationMs;
+    private final long hubRefreshDurationMs;
+
     public ServiceFinderHub(
             ServiceDataSource serviceDataSource,
-            ServiceFinderFactory<T, R> finderFactory) {
+            ServiceFinderFactory<T, R> finderFactory
+    ) {
+        this(serviceDataSource, finderFactory,
+                10_000, 30_000);
+    }
+
+    public ServiceFinderHub(
+            ServiceDataSource serviceDataSource,
+            ServiceFinderFactory<T, R> finderFactory,
+            long serviceRefreshDurationMs,
+            long hubRefreshDurationMs) {
         this.serviceDataSource = serviceDataSource;
         this.finderFactory = finderFactory;
+        this.serviceRefreshDurationMs = serviceRefreshDurationMs;
+        this.hubRefreshDurationMs = hubRefreshDurationMs;
         this.refreshSignals.add(new ScheduledSignal<>("service-hub-updater",
                 () -> null,
                 Collections.emptyList(),
@@ -81,22 +98,20 @@ public class ServiceFinderHub<T, R extends ServiceRegistry<T>> {
         return Optional.ofNullable(finders.get().get(service));
     }
 
-    public CompletableFuture<ServiceFinder<T, R>> buildFinder(final Service service) {
+    public ServiceFinder<T, R> buildFinder(final Service service) {
         val finder = finders.get().get(service);
-        if (finder != null) {
-            return CompletableFuture.completedFuture(finder);
+        if (null != finder) {
+            return finder;
         }
         serviceDataSource.add(service);
-        return CompletableFuture.supplyAsync(() -> {
-            try {
-                updateAvailable();
-                waitTillServiceIsReady(service);
-                return finders.get().get(service);
-            } catch(Exception e) {
-                log.warn("Exception whiling building finder", e);
-                throw e;
-            }
-        });
+        try {
+            updateAvailable();
+            waitTillServiceIsReady(service);
+            return finders.get().get(service);
+        } catch(Exception e) {
+            log.warn("Exception whiling building finder", e);
+            throw e;
+        }
     }
 
     public void start() {
@@ -190,13 +205,31 @@ public class ServiceFinderHub<T, R extends ServiceRegistry<T>> {
     }
 
     private void waitTillHubIsReady() {
-        serviceDataSource.services().forEach(this::waitTillServiceIsReady);
+        val hubRefresher = CompletableFuture.allOf(
+                serviceDataSource.services()
+                        .stream()
+                        .map(service -> CompletableFuture.supplyAsync((Supplier<Void>) () -> {
+                            waitTillServiceIsReady(service);
+                            return null;
+                        })).toArray(CompletableFuture[]::new)
+        );
+        try {
+            hubRefresher.get(hubRefreshDurationMs, TimeUnit.MILLISECONDS);
+        } catch (InterruptedException ie) {
+            Thread.currentThread().interrupt();
+            Exceptions
+                    .illegalState("Couldn't perform hub refresh at this time. Refresh exceeded the start up time specified");
+        } catch (Exception e) {
+            Exceptions
+                    .illegalState("Couldn't perform hub refresh at this time", e);
+        }
     }
 
     private void waitTillServiceIsReady(Service service) {
         try {
             RetryerBuilder.<Boolean>newBuilder()
                     .retryIfResult(r -> !r)
+                    .withStopStrategy(StopStrategies.stopAfterDelay(serviceRefreshDurationMs, TimeUnit.MILLISECONDS))
                     .build()
                     .call(() -> Optional.ofNullable(getFinders().get().get(service))
                             .map(ServiceFinder::getServiceRegistry)

--- a/ranger-core/src/main/java/io/appform/ranger/core/finderhub/ServiceFinderHubBuilder.java
+++ b/ranger-core/src/main/java/io/appform/ranger/core/finderhub/ServiceFinderHubBuilder.java
@@ -37,6 +37,8 @@ public abstract class ServiceFinderHubBuilder<T, R extends ServiceRegistry<T>> {
     private final List<Consumer<Void>> extraStartSignalConsumers = new ArrayList<>();
     private final List<Consumer<Void>> extraStopSignalConsumers = new ArrayList<>();
     private final List<Signal<Void>> extraRefreshSignals = new ArrayList<>();
+    private long serviceRefreshDurationMs = 10_000;
+    private long hubRefreshDurationMs = 30_000;
 
     public ServiceFinderHubBuilder<T, R> withServiceDataSource(ServiceDataSource serviceDataSource) {
         this.serviceDataSource = serviceDataSource;
@@ -68,12 +70,23 @@ public abstract class ServiceFinderHubBuilder<T, R extends ServiceRegistry<T>> {
         return this;
     }
 
+    public ServiceFinderHubBuilder<T, R> withServiceRefreshDuration(long serviceRefreshDurationMs) {
+        this.serviceRefreshDurationMs = serviceRefreshDurationMs;
+        return this;
+    }
+
+    public ServiceFinderHubBuilder<T, R> withHubRefreshDuration(long hubRefreshDurationMs) {
+        this.hubRefreshDurationMs = hubRefreshDurationMs;
+        return this;
+    }
+
     public ServiceFinderHub<T, R> build() {
         preBuild();
         Preconditions.checkNotNull(serviceDataSource, "Provide a non-null service data source");
         Preconditions.checkNotNull(serviceFinderFactory, "Provide a non-null service finder factory");
 
-        val hub = new ServiceFinderHub<>(serviceDataSource, serviceFinderFactory);
+        val hub = new ServiceFinderHub<>(serviceDataSource, serviceFinderFactory,
+                serviceRefreshDurationMs, hubRefreshDurationMs);
         final ScheduledSignal<Void> refreshSignal = new ScheduledSignal<>("service-hub-refresh-timer",
                                                                           () -> null,
                                                                           Collections.emptyList(),

--- a/ranger-core/src/main/java/io/appform/ranger/core/finderhub/ServiceFinderHubBuilder.java
+++ b/ranger-core/src/main/java/io/appform/ranger/core/finderhub/ServiceFinderHubBuilder.java
@@ -16,6 +16,7 @@
 package io.appform.ranger.core.finderhub;
 
 import com.google.common.base.Preconditions;
+import io.appform.ranger.core.model.HubConstants;
 import io.appform.ranger.core.model.ServiceRegistry;
 import io.appform.ranger.core.signals.ScheduledSignal;
 import io.appform.ranger.core.signals.Signal;
@@ -33,12 +34,12 @@ import java.util.function.Consumer;
 public abstract class ServiceFinderHubBuilder<T, R extends ServiceRegistry<T>> {
     private ServiceDataSource serviceDataSource;
     private ServiceFinderFactory<T, R> serviceFinderFactory;
-    private long refreshFrequencyMs = 10_000;
+    private long refreshFrequencyMs = HubConstants.REFRESH_FREQUENCY_MS;
     private final List<Consumer<Void>> extraStartSignalConsumers = new ArrayList<>();
     private final List<Consumer<Void>> extraStopSignalConsumers = new ArrayList<>();
     private final List<Signal<Void>> extraRefreshSignals = new ArrayList<>();
-    private long serviceRefreshDurationMs = 10_000;
-    private long hubRefreshDurationMs = 30_000;
+    private long serviceRefreshDurationMs = HubConstants.SERVICE_REFRESH_DURATION_MS;
+    private long hubRefreshDurationMs = HubConstants.HUB_REFRESH_DURATION_MS;
 
     public ServiceFinderHubBuilder<T, R> withServiceDataSource(ServiceDataSource serviceDataSource) {
         this.serviceDataSource = serviceDataSource;

--- a/ranger-core/src/main/java/io/appform/ranger/core/model/HubConstants.java
+++ b/ranger-core/src/main/java/io/appform/ranger/core/model/HubConstants.java
@@ -1,24 +1,27 @@
 /*
  * Copyright 2015 Flipkart Internet Pvt. Ltd.
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.appform.ranger.client;
+package io.appform.ranger.core.model;
 
 import lombok.experimental.UtilityClass;
 
 @UtilityClass
-public class RangerClientConstants {
-    public static final int CONNECTION_RETRY_TIME = 5000;
-    public static final int MINIMUM_REFRESH_TIME = 5000;
+public class HubConstants {
+    public static long SERVICE_REFRESH_DURATION_MS = 10_000;
+    public static long HUB_REFRESH_DURATION_MS = 30_000;
+    public static long REFRESH_FREQUENCY_MS = 10_000;
+    public static final int CONNECTION_RETRY_TIME_MS = 5_000;
+    public static final int MINIMUM_REFRESH_TIME_MS = 5_000;
 }

--- a/ranger-core/src/test/java/io/appform/ranger/core/finderhub/ServiceFinderHubTest.java
+++ b/ranger-core/src/test/java/io/appform/ranger/core/finderhub/ServiceFinderHubTest.java
@@ -16,7 +16,6 @@ import io.appform.ranger.core.utils.RangerTestUtils;
 import lombok.val;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.function.Executable;
 
 import java.util.ArrayList;
 import java.util.HashSet;

--- a/ranger-core/src/test/java/io/appform/ranger/core/finderhub/ServiceFinderHubTest.java
+++ b/ranger-core/src/test/java/io/appform/ranger/core/finderhub/ServiceFinderHubTest.java
@@ -44,7 +44,7 @@ class ServiceFinderHubTest {
         Assertions.assertEquals("HOST", node.get().getHost());
         Assertions.assertEquals(0, node.get().getPort());
 
-        val dynamicServiceFinder = serviceFinderHub.buildFinder(new Service("NS", "SERVICE"));
+        val dynamicServiceFinder = serviceFinderHub.buildFinder(new Service("NS", "SERVICE")).join();
         val dynamicServiceNode = dynamicServiceFinder.get(null, (criteria, serviceRegistry) -> serviceRegistry.nodeList());
         Assertions.assertTrue(dynamicServiceNode.isPresent());
         Assertions.assertEquals("HOST", dynamicServiceNode.get().getHost());
@@ -85,7 +85,7 @@ class ServiceFinderHubTest {
                 .build());
         serviceFinderHub.start();
         try {
-            serviceFinderHub.buildFinder(new Service("NS", "SERVICE_NAME"));
+            serviceFinderHub.buildFinder(new Service("NS", "SERVICE_NAME")).join();
             Assertions.fail("Exception should have been thrown");
         } catch (Exception exception) {
             Assertions.assertTrue(exception instanceof UnsupportedOperationException, "Unsupported exception should be thrown");

--- a/ranger-core/src/test/java/io/appform/ranger/core/finderhub/ServiceFinderHubTest.java
+++ b/ranger-core/src/test/java/io/appform/ranger/core/finderhub/ServiceFinderHubTest.java
@@ -11,9 +11,12 @@ import io.appform.ranger.core.healthcheck.HealthcheckStatus;
 import io.appform.ranger.core.model.*;
 import io.appform.ranger.core.units.TestNodeData;
 import java.util.Optional;
+
+import io.appform.ranger.core.utils.RangerTestUtils;
 import lombok.val;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -41,9 +44,7 @@ class ServiceFinderHubTest {
         Assertions.assertEquals("HOST", node.get().getHost());
         Assertions.assertEquals(0, node.get().getPort());
 
-        serviceFinderHub.buildFinder(new Service("NS", "SERVICE")).join();
-        val dynamicServiceFinder = serviceFinderHub.finder(new Service("NS", "SERVICE"))
-                .orElseThrow(() -> new IllegalStateException("Finder should be present"));
+        val dynamicServiceFinder = serviceFinderHub.buildFinder(new Service("NS", "SERVICE"));
         val dynamicServiceNode = dynamicServiceFinder.get(null, (criteria, serviceRegistry) -> serviceRegistry.nodeList());
         Assertions.assertTrue(dynamicServiceNode.isPresent());
         Assertions.assertEquals("HOST", dynamicServiceNode.get().getHost());
@@ -51,20 +52,31 @@ class ServiceFinderHubTest {
     }
 
     @Test
-    void testDynamicServiceAdditionAsync() throws InterruptedException {
+    void testDelayedServiceAddition() {
+        val delayedHub = new ServiceFinderHub<>(new DynamicDataSource(Lists.newArrayList(new Service("NS", "SERVICE"))),
+                service ->  new TestServiceFinderBuilder()
+                        .withNamespace(service.getNamespace())
+                        .withServiceName(service.getServiceName())
+                        .withDeserializer(new Deserializer<TestNodeData>() {})
+                        .withSleepDuration(5)
+                        .build(), 1_000, 5_000
+        );
+        Assertions.assertThrows(IllegalStateException.class, delayedHub::start);
+        val serviceFinderHub = new ServiceFinderHub<>(new DynamicDataSource(Lists.newArrayList(new Service("NS", "SERVICE"))),
+                service ->  new TestServiceFinderBuilder()
+                        .withNamespace(service.getNamespace())
+                        .withServiceName(service.getServiceName())
+                        .withDeserializer(new Deserializer<TestNodeData>() {})
+                        .withSleepDuration(1)
+                        .build(), 2_000, 5_000
+        );
         serviceFinderHub.start();
-        serviceFinderHub.buildFinder(new Service("NS", "SERVICE_NAME"));
-        val finderOpt = serviceFinderHub.finder(new Service("NS", "SERVICE_NAME"));
-        Assertions.assertFalse(finderOpt.isPresent(), "Finders will not be availbale immediately");
-        Thread.sleep(1000);
-        val finderAfterWaitOpt = serviceFinderHub.finder(new Service("NS", "SERVICE_NAME"));
-        Assertions.assertTrue(finderAfterWaitOpt.isPresent(), "Finders should be availble after some time");
+        Assertions.assertTrue(serviceFinderHub.finder(new Service("NS", "SERVICE")).isPresent());
     }
 
 
     @Test
     void testDynamicServiceAdditionWithNonDynamicDataSource() {
-
         val serviceFinderHub = new ServiceFinderHub<>(new StaticDataSource(new HashSet<>()), service -> new TestServiceFinderBuilder()
                 .withNamespace(service.getNamespace())
                 .withServiceName(service.getServiceName())
@@ -73,8 +85,7 @@ class ServiceFinderHubTest {
                 .build());
         serviceFinderHub.start();
         try {
-            val future = serviceFinderHub.buildFinder(new Service("NS", "SERVICE_NAME"));
-            future.join();
+            serviceFinderHub.buildFinder(new Service("NS", "SERVICE_NAME"));
             Assertions.fail("Exception should have been thrown");
         } catch (Exception exception) {
             Assertions.assertTrue(exception instanceof UnsupportedOperationException, "Unsupported exception should be thrown");
@@ -82,6 +93,8 @@ class ServiceFinderHubTest {
     }
 
     private static class TestServiceFinderBuilder extends BaseServiceFinderBuilder<TestNodeData, MapBasedServiceRegistry<TestNodeData>, ServiceFinder<TestNodeData, MapBasedServiceRegistry<TestNodeData>>, TestServiceFinderBuilder, Deserializer<TestNodeData>> {
+
+        private int finderSleepDurationSeconds = 0;
 
         @Override
         public ServiceFinder<TestNodeData, MapBasedServiceRegistry<TestNodeData>> build() {
@@ -97,11 +110,16 @@ class ServiceFinderHubTest {
 
         @Override
         protected ServiceFinder<TestNodeData, MapBasedServiceRegistry<TestNodeData>> buildFinder(Service service, ShardSelector<TestNodeData, MapBasedServiceRegistry<TestNodeData>> shardSelector, ServiceNodeSelector<TestNodeData> nodeSelector) {
+            RangerTestUtils.sleepUntil(finderSleepDurationSeconds);
             if (null == shardSelector) {
                 shardSelector = new MatchingShardSelector<>();
             }
             return new SimpleShardedServiceFinder<>(new MapBasedServiceRegistry<>(service), shardSelector, nodeSelector);
+        }
 
+        public TestServiceFinderBuilder withSleepDuration(final int finderSleepDurationSeconds) {
+            this.finderSleepDurationSeconds = finderSleepDurationSeconds;
+            return this;
         }
 
         private static class TestNodeDataSource implements NodeDataSource<TestNodeData, Deserializer<TestNodeData>> {

--- a/ranger-http-client/pom.xml
+++ b/ranger-http-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>ranger</artifactId>
         <groupId>io.appform.ranger</groupId>
-        <version>1.1-RC1</version>
+        <version>1.1-RC2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/ranger-http-client/src/main/java/io/appform/ranger/client/http/AbstractRangerHttpHubClient.java
+++ b/ranger-http-client/src/main/java/io/appform/ranger/client/http/AbstractRangerHttpHubClient.java
@@ -51,6 +51,8 @@ public abstract class AbstractRangerHttpHubClient<T, R extends ServiceRegistry<T
         .withServiceDataSource(getServiceDataSource())
         .withServiceFinderFactory(getFinderFactory())
         .withRefreshFrequencyMs(getNodeRefreshTimeMs())
+        .withHubRefreshDuration(getHubRefreshDurationMs())
+        .withServiceRefreshDuration(getServiceRefreshDurationMs())
         .build();
   }
 }

--- a/ranger-http-model/pom.xml
+++ b/ranger-http-model/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>ranger</artifactId>
         <groupId>io.appform.ranger</groupId>
-        <version>1.1-RC1</version>
+        <version>1.1-RC2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/ranger-http/pom.xml
+++ b/ranger-http/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>ranger</artifactId>
         <groupId>io.appform.ranger</groupId>
-        <version>1.1-RC1</version>
+        <version>1.1-RC2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/ranger-hub-server-bundle/pom.xml
+++ b/ranger-hub-server-bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>ranger</artifactId>
         <groupId>io.appform.ranger</groupId>
-        <version>1.0-RC18</version>
+        <version>1.1-RC2</version>
     </parent>
     <build>
         <plugins>

--- a/ranger-hub-server-bundle/src/main/java/io/appform/ranger/hub/server/bundle/RangerHubServerBundle.java
+++ b/ranger-hub-server-bundle/src/main/java/io/appform/ranger/hub/server/bundle/RangerHubServerBundle.java
@@ -17,12 +17,12 @@ package io.appform.ranger.hub.server.bundle;
 
 import com.codahale.metrics.health.HealthCheck;
 import com.fasterxml.jackson.core.type.TypeReference;
-import io.appform.ranger.client.RangerClientConstants;
 import io.appform.ranger.client.RangerHubClient;
 import io.appform.ranger.client.http.UnshardedRangerHttpHubClient;
 import io.appform.ranger.client.zk.UnshardedRangerZKHubClient;
 import io.appform.ranger.common.server.ShardInfo;
 import io.appform.ranger.core.finder.serviceregistry.ListBasedServiceRegistry;
+import io.appform.ranger.core.model.HubConstants;
 import io.appform.ranger.core.model.ServiceNode;
 import io.appform.ranger.core.signals.Signal;
 import io.appform.ranger.http.config.HttpClientConfig;
@@ -88,7 +88,7 @@ public abstract class RangerHubServerBundle<U extends Configuration>
             val curatorFramework = CuratorFrameworkFactory.builder()
                     .connectString(zookeeper)
                     .namespace(namespace)
-                    .retryPolicy(new RetryForever(RangerClientConstants.CONNECTION_RETRY_TIME))
+                    .retryPolicy(new RetryForever(HubConstants.CONNECTION_RETRY_TIME_MS))
                     .build();
             curatorFrameworks.add(curatorFramework);
             return UnshardedRangerZKHubClient.<ShardInfo>builder()

--- a/ranger-hub-server-bundle/src/main/java/io/appform/ranger/hub/server/bundle/configuration/RangerUpstreamConfiguration.java
+++ b/ranger-hub-server-bundle/src/main/java/io/appform/ranger/hub/server/bundle/configuration/RangerUpstreamConfiguration.java
@@ -17,7 +17,7 @@ package io.appform.ranger.hub.server.bundle.configuration;
 
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import io.appform.ranger.client.RangerClientConstants;
+import io.appform.ranger.core.model.HubConstants;
 import io.appform.ranger.hub.server.bundle.models.BackendType;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -37,8 +37,8 @@ public abstract class RangerUpstreamConfiguration {
   @NotNull
   private BackendType type;
 
-  @Min(RangerClientConstants.MINIMUM_REFRESH_TIME)
-  private int nodeRefreshTimeMs = RangerClientConstants.MINIMUM_REFRESH_TIME;
+  @Min(HubConstants.MINIMUM_REFRESH_TIME_MS)
+  private int nodeRefreshTimeMs = HubConstants.MINIMUM_REFRESH_TIME_MS;
 
   protected RangerUpstreamConfiguration(BackendType type) {
     this.type = type;

--- a/ranger-server-bundle/pom.xml
+++ b/ranger-server-bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>ranger</artifactId>
         <groupId>io.appform.ranger</groupId>
-        <version>1.1-RC1</version>
+        <version>1.1-RC2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/ranger-server-common/pom.xml
+++ b/ranger-server-common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>ranger</artifactId>
         <groupId>io.appform.ranger</groupId>
-        <version>1.1-RC1</version>
+        <version>1.1-RC2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/ranger-server/pom.xml
+++ b/ranger-server/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.appform.ranger</groupId>
         <artifactId>ranger</artifactId>
-        <version>1.0-RC18</version>
+        <version>1.1-RC2</version>
     </parent>
 
     <artifactId>ranger-server</artifactId>

--- a/ranger-zk-client/pom.xml
+++ b/ranger-zk-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>ranger</artifactId>
         <groupId>io.appform.ranger</groupId>
-        <version>1.1-RC1</version>
+        <version>1.1-RC2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/ranger-zk-client/src/main/java/io/appform/ranger/client/zk/AbstractRangerZKHubClient.java
+++ b/ranger-zk-client/src/main/java/io/appform/ranger/client/zk/AbstractRangerZKHubClient.java
@@ -46,6 +46,8 @@ public abstract class AbstractRangerZKHubClient<T, R extends ServiceRegistry<T>,
                 .withRefreshFrequencyMs(getNodeRefreshTimeMs())
                 .withServiceDataSource(getServiceDataSource())
                 .withServiceFinderFactory(getFinderFactory())
+                .withHubRefreshDuration(getHubRefreshDurationMs())
+                .withServiceRefreshDuration(getServiceRefreshDurationMs())
                 .build();
     }
 

--- a/ranger-zk-client/src/main/java/io/appform/ranger/client/zk/SimpleRangerZKClient.java
+++ b/ranger-zk-client/src/main/java/io/appform/ranger/client/zk/SimpleRangerZKClient.java
@@ -18,10 +18,10 @@ package io.appform.ranger.client.zk;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Preconditions;
 import io.appform.ranger.client.AbstractRangerClient;
-import io.appform.ranger.client.RangerClientConstants;
 import io.appform.ranger.core.finder.SimpleShardedServiceFinder;
 import io.appform.ranger.core.finder.serviceregistry.MapBasedServiceRegistry;
 import io.appform.ranger.core.finder.shardselector.MatchingShardSelector;
+import io.appform.ranger.core.model.HubConstants;
 import io.appform.ranger.core.model.ShardSelector;
 import io.appform.ranger.zookeeper.ServiceFinderBuilders;
 import io.appform.ranger.zookeeper.serde.ZkNodeDataDeserializer;
@@ -60,11 +60,11 @@ public class SimpleRangerZKClient<T> extends AbstractRangerClient<T, MapBasedSer
 
         int effectiveRefreshTime = nodeRefreshIntervalMs;
 
-        if (effectiveRefreshTime < RangerClientConstants.MINIMUM_REFRESH_TIME) {
-            effectiveRefreshTime = RangerClientConstants.MINIMUM_REFRESH_TIME;
+        if (effectiveRefreshTime < HubConstants.MINIMUM_REFRESH_TIME_MS) {
+            effectiveRefreshTime = HubConstants.MINIMUM_REFRESH_TIME_MS;
             log.warn("Node info update interval too low: {} ms. Has been upgraded to {} ms ",
                      nodeRefreshIntervalMs,
-                     RangerClientConstants.MINIMUM_REFRESH_TIME);
+                    HubConstants.MINIMUM_REFRESH_TIME_MS);
         }
 
         if (null == curatorFramework) {
@@ -72,7 +72,7 @@ public class SimpleRangerZKClient<T> extends AbstractRangerClient<T, MapBasedSer
             curatorFramework = CuratorFrameworkFactory.builder()
                     .connectString(connectionString)
                     .namespace(namespace)
-                    .retryPolicy(new RetryForever(RangerClientConstants.CONNECTION_RETRY_TIME))
+                    .retryPolicy(new RetryForever(HubConstants.CONNECTION_RETRY_TIME_MS))
                     .build();
         }
 

--- a/ranger-zookeeper/pom.xml
+++ b/ranger-zookeeper/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>ranger</artifactId>
         <groupId>io.appform.ranger</groupId>
-        <version>1.1-RC1</version>
+        <version>1.1-RC2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
This is pertaining to the dynamic service addition [PR](https://github.com/appform-io/ranger/pull/22/)

### What? 

Dynamic Finder Construction via CompletableFuture (..) requires every client that interacts with ranger to implement the boundary within, and also solves only a part of the problem. The other half is, hubRefresh also needs to be similarly bounded.

### Why?

If the clients don't handle the timeout on creation of a serviceFinder, by specifying a timeout on CompletableFuture provided - there is a risk that they will run into an infinite loop, since finder refresh will wait eternally. Same with the hub. In cases where the node_data_sources are unreachable or latent, this may manifest. This boundary condition exits that infinite loop. (This when a nodeDataSource is unreachable)

If the upstream a service is calling is down, it has no impact on the service coming up - it is not to be confused with that. The service will still come up with empty nodes for the stream. Please check the implementations of node_data_source refresh for both zk and http for the same. 

### How?

Introduced hubStartDurationMs and finderRefreshDurationMs for defining the boundary, in the hubBuilder. If this boundary were to breach, throw with an IllegalStateException. 

Added tests, upgraded versions and updated CHANGELOG.

Also, this [PR](https://github.com/appform-io/ranger/pull/39) may not be required anymore. 