### PR TITLE
    Stability fixes and optimizations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <guava.version>33.2.0-jre</guava.version>
+        <guava.version>33.3.0-jre</guava.version>
         <curator.version>5.5.0</curator.version>
         <slf4j.version>1.7.32</slf4j.version>
 
@@ -116,7 +116,7 @@
         <wiremock.version>3.3.1</wiremock.version>
         <mockito.version>4.2.0</mockito.version>
 
-        <dropwizard.version>2.1.10</dropwizard.version>
+        <dropwizard.version>2.1.12</dropwizard.version>
         <logback.version>1.2.12</logback.version>
     </properties>
 

--- a/ranger-client/src/test/java/io/appform/ranger/client/stubs/TestSimpleUnshardedServiceFinder.java
+++ b/ranger-client/src/test/java/io/appform/ranger/client/stubs/TestSimpleUnshardedServiceFinder.java
@@ -22,11 +22,11 @@ import io.appform.ranger.core.model.NodeDataSource;
 import io.appform.ranger.core.model.Service;
 import io.appform.ranger.core.model.ServiceNode;
 import io.appform.ranger.core.units.TestNodeData;
-import java.util.Optional;
 import lombok.Builder;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 @Builder
 public class TestSimpleUnshardedServiceFinder <T>
@@ -51,6 +51,7 @@ public class TestSimpleUnshardedServiceFinder <T>
                             .host("localhost")
                             .port(9200)
                             .nodeData(TestNodeData.builder().shardId(1).build())
+                            .lastUpdatedTimeStamp(Long.MAX_VALUE)
                             .build())
             );
         }

--- a/ranger-core/src/main/java/io/appform/ranger/core/exceptions/CommunicationException.java
+++ b/ranger-core/src/main/java/io/appform/ranger/core/exceptions/CommunicationException.java
@@ -14,15 +14,13 @@
  * limitations under the License.
  */
 
-package io.appform.ranger.drove.common;
-
-import io.appform.ranger.core.exceptions.CommunicationException;
+package io.appform.ranger.core.exceptions;
 
 /**
- * Thrown in case there is an issue communicating with the drove upstream.
+ * Base for communication exception
  */
-public class DroveCommunicationException extends CommunicationException {
-    public DroveCommunicationException(final String message) {
+public abstract class CommunicationException extends RuntimeException {
+    protected CommunicationException(final String message) {
         super(message);
     }
 }

--- a/ranger-core/src/main/java/io/appform/ranger/core/finder/serviceregistry/ServiceRegistryUpdater.java
+++ b/ranger-core/src/main/java/io/appform/ranger/core/finder/serviceregistry/ServiceRegistryUpdater.java
@@ -16,13 +16,16 @@
 package io.appform.ranger.core.finder.serviceregistry;
 
 import com.github.rholder.retry.RetryerBuilder;
+import com.github.rholder.retry.WaitStrategies;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Stopwatch;
+import io.appform.ranger.core.healthcheck.HealthcheckStatus;
 import io.appform.ranger.core.model.Deserializer;
 import io.appform.ranger.core.model.NodeDataSource;
 import io.appform.ranger.core.model.ServiceRegistry;
 import io.appform.ranger.core.signals.Signal;
 import io.appform.ranger.core.util.Exceptions;
+import io.appform.ranger.core.util.FinderUtils;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 
@@ -39,7 +42,7 @@ import java.util.concurrent.locks.ReentrantLock;
 public class ServiceRegistryUpdater<T, D extends Deserializer<T>> {
 
     private final ServiceRegistry<T> serviceRegistry;
-    private final NodeDataSource<T,D> nodeDataSource;
+    private final NodeDataSource<T, D> nodeDataSource;
     private final D deserializer;
 
     private final Lock checkLock = new ReentrantLock();
@@ -51,7 +54,7 @@ public class ServiceRegistryUpdater<T, D extends Deserializer<T>> {
 
     public ServiceRegistryUpdater(
             ServiceRegistry<T> serviceRegistry,
-            NodeDataSource<T,D> nodeDataSource,
+            NodeDataSource<T, D> nodeDataSource,
             List<Signal<T>> signalGenerators,
             D deserializer) {
         this.serviceRegistry = serviceRegistry;
@@ -70,6 +73,8 @@ public class ServiceRegistryUpdater<T, D extends Deserializer<T>> {
         try {
             RetryerBuilder.<Boolean>newBuilder()
                     .retryIfResult(r -> null == r || !r)
+                    .retryIfException()
+                    .withWaitStrategy(WaitStrategies.fixedWait(1, TimeUnit.SECONDS))
                     .build()
                     .call(serviceRegistry::isRefreshed);
         }
@@ -81,7 +86,7 @@ public class ServiceRegistryUpdater<T, D extends Deserializer<T>> {
     }
 
     public void stop() {
-        if(null != queryThreadFuture) {
+        if (null != queryThreadFuture) {
             executorService.shutdownNow();
         }
     }
@@ -125,21 +130,42 @@ public class ServiceRegistryUpdater<T, D extends Deserializer<T>> {
 
     private void updateRegistry() throws InterruptedException {
         log.debug("Checking for updates on data source for service: {}",
-                     serviceRegistry.getService().getServiceName());
-        if(!nodeDataSource.isActive()) {
-            log.warn("Node data source seems to be down. Keeping old list for {}",
-                        serviceRegistry.getService().getServiceName());
-            return;
+                  serviceRegistry.getService().getServiceName());
+        var callFailed = false;
+        if (nodeDataSource.isActive()) { //Source should implement circuit breaker to fail fast and reopen after some
+            // time
+            try {
+                val nodeList = nodeDataSource.refresh(deserializer).orElse(null);
+                if (null != nodeList) {
+                    log.debug("Updating nodeList of size: {} for [{}]", nodeList.size(),
+                              serviceRegistry.getService().getServiceName());
+                    val livenessCheckMaxAge = nodeDataSource.healthcheckZombieCheckThresholdTime(serviceRegistry.getService());
+                    //Remove all stale nodes before updating. This is done centrally to ensure some data sources
+                    //don't skip this check. Some control is still provided so that they can overload.
+                    serviceRegistry.updateNodes(FinderUtils.filterValidNodes(serviceRegistry.getService(), nodeList, livenessCheckMaxAge));
+                }
+                else {
+                    log.warn("Empty list returned from node data source. We are in a weird state. Keeping old list for {}",
+                            serviceRegistry.getService().getServiceName());
+                }
+            }
+            catch (Exception e) {
+                log.error("Error updating data from registry. Error: [{}] {}",
+                          e.getClass().getSimpleName(),
+                          e.getMessage());
+                callFailed = true;
+            }
         }
-        val nodeList = nodeDataSource.refresh(deserializer).orElse(null);
-        if (null != nodeList) {
-            log.debug("Updating nodeList of size: {} for [{}]", nodeList.size(),
-                         serviceRegistry.getService().getServiceName());
-            serviceRegistry.updateNodes(nodeList);
-        }
-        else {
-            log.warn("Empty list returned from node data source. We are in a weird state. Keeping old list for {}",
+        if (!nodeDataSource.isActive() || callFailed) {
+            val currTime = System.currentTimeMillis();
+            log.warn("Node data source seems to be down. Keeping old list for {}." +
+                             " Will update timestamp to keep stale date relevant.",
                      serviceRegistry.getService().getServiceName());
+            serviceRegistry.updateNodes(serviceRegistry.nodeList()
+                                                .stream()
+                                                .filter(node -> HealthcheckStatus.healthy == node.getHealthcheckStatus())
+                                                .map(node -> node.setLastUpdatedTimeStamp(currTime))
+                                                .toList());
         }
     }
 

--- a/ranger-core/src/main/java/io/appform/ranger/core/model/NodeDataSource.java
+++ b/ranger-core/src/main/java/io/appform/ranger/core/model/NodeDataSource.java
@@ -15,6 +15,8 @@
  */
 package io.appform.ranger.core.model;
 
+import io.appform.ranger.core.exceptions.CommunicationException;
+
 import java.util.List;
 import java.util.Optional;
 
@@ -24,9 +26,9 @@ import java.util.Optional;
 @SuppressWarnings("unused")
 public interface NodeDataSource<T, D extends Deserializer<T>> extends NodeDataStoreConnector<T> {
 
-    Optional<List<ServiceNode<T>>> refresh(D deserializer);
+    Optional<List<ServiceNode<T>>> refresh(D deserializer) throws CommunicationException;
 
     default long healthcheckZombieCheckThresholdTime(Service service) {
-        return System.currentTimeMillis() - 60000; //1 Minute
+        return isActive() ? (System.currentTimeMillis() - 60000) : 0; //1 Minute
     }
 }

--- a/ranger-core/src/main/java/io/appform/ranger/core/signals/ScheduledSignal.java
+++ b/ranger-core/src/main/java/io/appform/ranger/core/signals/ScheduledSignal.java
@@ -36,7 +36,7 @@ public class ScheduledSignal<T> extends Signal<T> {
     private final String name;
     private final long refreshIntervalMillis;
 
-    private final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1);
+    private final ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
 
     private ScheduledFuture<?> scheduledFuture = null;
 

--- a/ranger-core/src/test/java/io/appform/ranger/core/finderhub/ServiceFinderHubTest.java
+++ b/ranger-core/src/test/java/io/appform/ranger/core/finderhub/ServiceFinderHubTest.java
@@ -26,8 +26,6 @@ import io.appform.ranger.core.finder.shardselector.MatchingShardSelector;
 import io.appform.ranger.core.healthcheck.HealthcheckStatus;
 import io.appform.ranger.core.model.*;
 import io.appform.ranger.core.units.TestNodeData;
-import java.util.Optional;
-
 import io.appform.ranger.core.utils.RangerTestUtils;
 import lombok.val;
 import org.junit.jupiter.api.Assertions;
@@ -36,6 +34,7 @@ import org.junit.jupiter.api.Test;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 
 class ServiceFinderHubTest {
 
@@ -83,7 +82,7 @@ class ServiceFinderHubTest {
                         .withServiceName(service.getServiceName())
                         .withDeserializer(new Deserializer<TestNodeData>() {})
                         .withSleepDuration(1)
-                        .build(), 2_000, 5_000
+                        .build(), 5_000, 5_000
         );
         serviceFinderHub.start();
         Assertions.assertTrue(serviceFinderHub.finder(new Service("NS", "SERVICE")).isPresent());
@@ -141,7 +140,7 @@ class ServiceFinderHubTest {
             @Override
             public Optional<List<ServiceNode<TestNodeData>>> refresh(Deserializer<TestNodeData> deserializer) {
                 val list = new ArrayList<ServiceNode<TestNodeData>>();
-                list.add(new ServiceNode<>("HOST", 0, TestNodeData.builder().shardId(1).build(), HealthcheckStatus.healthy, 10L, "HTTP"));
+                list.add(new ServiceNode<>("HOST", 0, TestNodeData.builder().shardId(1).build(), HealthcheckStatus.healthy, Long.MAX_VALUE, "HTTP"));
                 return Optional.of(list);
             }
 

--- a/ranger-discovery-bundle/perf/results/io.appform.ranger.discovery.bundle.id.IdGeneratorPerfTest.testGenerate.json
+++ b/ranger-discovery-bundle/perf/results/io.appform.ranger.discovery.bundle.id.IdGeneratorPerfTest.testGenerate.json
@@ -4,5 +4,5 @@
   "iterations" : 4,
   "threads" : 1,
   "forks" : 3,
-  "mean_ops" : 787544.107063881
+  "mean_ops" : 812476.3197574528
 }

--- a/ranger-discovery-bundle/perf/results/io.appform.ranger.discovery.bundle.id.IdGeneratorPerfTest.testGenerateBase36.json
+++ b/ranger-discovery-bundle/perf/results/io.appform.ranger.discovery.bundle.id.IdGeneratorPerfTest.testGenerateBase36.json
@@ -4,5 +4,5 @@
   "iterations" : 4,
   "threads" : 1,
   "forks" : 3,
-  "mean_ops" : 594383.3501367184
+  "mean_ops" : 592802.8071907263
 }

--- a/ranger-drove/pom.xml
+++ b/ranger-drove/pom.xml
@@ -24,7 +24,7 @@
         <version>1.1-RC2</version>
     </parent>
     <properties>
-        <drove.version>1.29</drove.version>
+        <drove.version>1.30</drove.version>
     </properties>
     <modelVersion>4.0.0</modelVersion>
 

--- a/ranger-drove/src/main/java/io/appform/ranger/drove/common/DroveApiCommunicator.java
+++ b/ranger-drove/src/main/java/io/appform/ranger/drove/common/DroveApiCommunicator.java
@@ -117,7 +117,7 @@ public class DroveApiCommunicator implements DroveCommunicator {
     @Override
     @SuppressWarnings("java:S1168")
     public Map<Service, List<ExposedAppInfo>> listNodes(Iterable<? extends Service> services) {
-        log.info("Loading nodes list for services: {}", Lists.newArrayList(services));
+        log.debug("Loading nodes list for services: {}", Lists.newArrayList(services));
         val url = String.format("/apis/v1/endpoints?%s", Joiner.on("&")
                 .join(StreamSupport.stream(services.spliterator(), false)
                               .map(service -> "app=" + service.getServiceName())

--- a/ranger-drove/src/main/java/io/appform/ranger/drove/common/DroveCachingCommunicator.java
+++ b/ranger-drove/src/main/java/io/appform/ranger/drove/common/DroveCachingCommunicator.java
@@ -111,6 +111,11 @@ public class DroveCachingCommunicator implements DroveCommunicator {
     }
 
     @Override
+    public boolean healthy() {
+        return root.healthy();
+    }
+
+    @Override
     public List<String> services() {
         return root.services();
     }

--- a/ranger-drove/src/main/java/io/appform/ranger/drove/common/DroveCommunicator.java
+++ b/ranger-drove/src/main/java/io/appform/ranger/drove/common/DroveCommunicator.java
@@ -30,6 +30,8 @@ import java.util.Set;
 public interface DroveCommunicator extends AutoCloseable {
     Optional<String> leader();
 
+    boolean healthy();
+
     List<String> services();
 
     default List<ExposedAppInfo> listNodes(final Service service) {

--- a/ranger-drove/src/main/java/io/appform/ranger/drove/common/DroveNodeDataStoreConnector.java
+++ b/ranger-drove/src/main/java/io/appform/ranger/drove/common/DroveNodeDataStoreConnector.java
@@ -62,7 +62,7 @@ public class DroveNodeDataStoreConnector<T> implements NodeDataStoreConnector<T>
 
     @Override
     public boolean isActive() {
-        return droveClient.leader().isPresent();
+        return droveClient.healthy();
     }
 
 }

--- a/ranger-drove/src/main/java/io/appform/ranger/drove/common/DroveOkHttpTransport.java
+++ b/ranger-drove/src/main/java/io/appform/ranger/drove/common/DroveOkHttpTransport.java
@@ -68,7 +68,7 @@ public class DroveOkHttpTransport implements DroveHttpTransport {
             return responseHandler.handle(droveResponse);
         }
         catch (Exception e) {
-            log.error("Error calling drove: " + e.getMessage(), e);
+            log.error("Error calling drove: {}. Error: {}", e.getMessage(), e.getClass().getSimpleName());
             throw new DroveCommunicationException(e.getMessage());
         }
     }

--- a/ranger-drove/src/main/java/io/appform/ranger/drove/servicefinder/DroveNodeDataSource.java
+++ b/ranger-drove/src/main/java/io/appform/ranger/drove/servicefinder/DroveNodeDataSource.java
@@ -20,7 +20,6 @@ import com.google.common.base.Preconditions;
 import io.appform.ranger.core.model.NodeDataSource;
 import io.appform.ranger.core.model.Service;
 import io.appform.ranger.core.model.ServiceNode;
-import io.appform.ranger.core.util.FinderUtils;
 import io.appform.ranger.drove.common.DroveCommunicationException;
 import io.appform.ranger.drove.common.DroveCommunicator;
 import io.appform.ranger.drove.common.DroveNodeDataStoreConnector;
@@ -58,20 +57,17 @@ public class DroveNodeDataSource<T, D extends DroveResponseDataDeserializer<T>> 
             val exposedAppInfos = droveClient.listNodes(service);
             val nodes = deserializer.deserialize(
                     Objects.requireNonNull(exposedAppInfos, "Unexpected empty response from server"));
-            return Optional.of(FinderUtils.filterValidNodes(
-                    service,
-                    nodes,
-                    healthcheckZombieCheckThresholdTime(service)));
+            return Optional.of(nodes);
         }
         catch (DroveCommunicationException e) {
             log.error("Drove communication error", e);
             return Optional.empty(); //In case of refresh failure, maintain old list
         }
-
     }
 
     @Override
     public boolean isActive() {
-        return droveClient.leader().isPresent();
+        return droveClient.healthy();
     }
+
 }

--- a/ranger-http-client/src/main/java/io/appform/ranger/client/http/SimpleRangerHttpClient.java
+++ b/ranger-http-client/src/main/java/io/appform/ranger/client/http/SimpleRangerHttpClient.java
@@ -25,11 +25,11 @@ import io.appform.ranger.core.model.ShardSelector;
 import io.appform.ranger.http.HttpServiceFinderBuilders;
 import io.appform.ranger.http.config.HttpClientConfig;
 import io.appform.ranger.http.serde.HTTPResponseDataDeserializer;
+import io.appform.ranger.http.servicefinder.HttpCommunicator;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.experimental.SuperBuilder;
 import lombok.extern.slf4j.Slf4j;
-import okhttp3.OkHttpClient;
 
 @Slf4j
 @SuperBuilder
@@ -40,7 +40,7 @@ public class SimpleRangerHttpClient<T> extends AbstractRangerClient<T, ListBased
     private final ObjectMapper mapper;
     private final int nodeRefreshIntervalMs;
     private final HttpClientConfig clientConfig;
-    private final OkHttpClient httpClient;
+    private final HttpCommunicator<T> httpClient;
     private final HTTPResponseDataDeserializer<T> deserializer;
     @Builder.Default
     private final ShardSelector<T, ListBasedServiceRegistry<T>> shardSelector = new ListShardSelector<>();

--- a/ranger-http-client/src/test/java/io/appform/ranger/client/http/ShardedRangerHttpClientTest.java
+++ b/ranger-http-client/src/test/java/io/appform/ranger/client/http/ShardedRangerHttpClientTest.java
@@ -29,7 +29,7 @@ class ShardedRangerHttpClientTest extends BaseRangerHttpClientTest {
         val httpClientConfig = getHttpClientConfig();
         val client = ShardedRangerHttpHubClient.<TestNodeData>builder()
                 .clientConfig(httpClientConfig)
-                .httpClient(RangerHttpUtils.httpClient(httpClientConfig))
+                .httpClient(RangerHttpUtils.httpClient(httpClientConfig, getObjectMapper()))
                 .namespace("test-n")
                 .deserializer(this::read)
                 .mapper(getObjectMapper())

--- a/ranger-http-client/src/test/java/io/appform/ranger/client/http/SimpleRangerHttpClientTest.java
+++ b/ranger-http-client/src/test/java/io/appform/ranger/client/http/SimpleRangerHttpClientTest.java
@@ -30,7 +30,7 @@ class SimpleRangerHttpClientTest extends BaseRangerHttpClientTest{
         val client = SimpleRangerHttpClient.<TestNodeData>builder()
                 .clientConfig(httpClientConfig)
                 .mapper(getObjectMapper())
-                .httpClient(RangerHttpUtils.httpClient(httpClientConfig))
+                .httpClient(RangerHttpUtils.httpClient(httpClientConfig, getObjectMapper()))
                 .deserializer(this::read)
                 .namespace("test-n")
                 .serviceName("test-s")

--- a/ranger-http-client/src/test/java/io/appform/ranger/client/http/UnshardedRangerHttpClientTest.java
+++ b/ranger-http-client/src/test/java/io/appform/ranger/client/http/UnshardedRangerHttpClientTest.java
@@ -29,7 +29,7 @@ class UnshardedRangerHttpClientTest extends BaseRangerHttpClientTest {
         val httpClientConfig = getHttpClientConfig();
         val client = UnshardedRangerHttpHubClient.<TestNodeData>builder()
                 .clientConfig(httpClientConfig)
-                .httpClient(RangerHttpUtils.httpClient(httpClientConfig))
+                .httpClient(RangerHttpUtils.httpClient(httpClientConfig, getObjectMapper()))
                 .namespace("test-n")
                 .deserializer(this::read)
                 .mapper(getObjectMapper())

--- a/ranger-http/src/main/java/io/appform/ranger/http/common/HttpNodeDataStoreConnector.java
+++ b/ranger-http/src/main/java/io/appform/ranger/http/common/HttpNodeDataStoreConnector.java
@@ -15,11 +15,10 @@
  */
 package io.appform.ranger.http.common;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.appform.ranger.core.model.NodeDataStoreConnector;
 import io.appform.ranger.http.config.HttpClientConfig;
+import io.appform.ranger.http.servicefinder.HttpCommunicator;
 import lombok.extern.slf4j.Slf4j;
-import okhttp3.OkHttpClient;
 
 /**
  *
@@ -28,16 +27,13 @@ import okhttp3.OkHttpClient;
 public class HttpNodeDataStoreConnector<T> implements NodeDataStoreConnector<T> {
 
     protected final HttpClientConfig config;
-    protected final ObjectMapper mapper;
-    protected final OkHttpClient httpClient;
+    protected final HttpCommunicator<T> httpCommunicator;
 
     public HttpNodeDataStoreConnector(
             final HttpClientConfig config,
-            final ObjectMapper mapper,
-            final OkHttpClient httpClient) {
-        this.httpClient = httpClient;
+            final HttpCommunicator<T> httpCommunicator) {
+        this.httpCommunicator = httpCommunicator;
         this.config = config;
-        this.mapper = mapper;
     }
 
 

--- a/ranger-http/src/main/java/io/appform/ranger/http/servicefinder/HttpApiCommunicator.java
+++ b/ranger-http/src/main/java/io/appform/ranger/http/servicefinder/HttpApiCommunicator.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright 2024 Authors, Flipkart Internet Pvt. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.appform.ranger.http.servicefinder;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.appform.ranger.core.model.Service;
+import io.appform.ranger.core.model.ServiceNode;
+import io.appform.ranger.http.config.HttpClientConfig;
+import io.appform.ranger.http.model.ServiceDataSourceResponse;
+import io.appform.ranger.http.serde.HTTPResponseDataDeserializer;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import lombok.val;
+import okhttp3.HttpUrl;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Supplier;
+
+/**
+ * Direct api based communication
+ */
+@Slf4j
+public class HttpApiCommunicator<T> implements HttpCommunicator<T> {
+    private final AtomicBoolean upstreamAvailable = new AtomicBoolean(true);
+    private final ScheduledExecutorService resetter = Executors.newSingleThreadScheduledExecutor();
+
+    @Getter
+    private final OkHttpClient httpClient;
+    private final HttpClientConfig config;
+    private final ObjectMapper mapper;
+
+    public HttpApiCommunicator(OkHttpClient httpClient, HttpClientConfig config, ObjectMapper mapper) {
+        Objects.requireNonNull(mapper, "mapper has not been set for node data");
+        this.httpClient = httpClient;
+        this.config = config;
+        this.mapper = mapper;
+        resetter.scheduleWithFixedDelay(() -> upstreamAvailable.set(true), 0, 60, TimeUnit.SECONDS);
+    }
+
+    @Override
+    public boolean healthy() {
+        return upstreamAvailable.get();
+    }
+
+    @Override
+    public Set<Service> services() {
+        return executeRemoteCall(() -> {
+            val httpUrl = new HttpUrl.Builder()
+                    .scheme(config.isSecure() ? "https" : "http")
+                    .host(config.getHost())
+                    .port(config.getPort() == 0 ? defaultPort() : config.getPort())
+                    .encodedPath("/ranger/services/v1")
+                    .build();
+            val request = new Request.Builder()
+                    .url(httpUrl)
+                    .get()
+                    .build();
+
+            try (val response = httpClient.newCall(request).execute()) {
+                if (response.isSuccessful()) {
+                    return parseServices(response, httpUrl);
+                }
+                else {
+                    throw new HttpCommunicationException(
+                            "Http call to returned a failure response. Url:" + httpUrl + " status: " + response.code());
+                }
+            }
+            catch (Exception e) {
+                throw new HttpCommunicationException(
+                        "Error parsing the response from server for url: " + httpUrl
+                                + " with exception " + e.getClass().getSimpleName() + ": " + e.getMessage());
+            }
+        });
+    }
+
+    @Override
+    public List<ServiceNode<T>> listNodes(
+            Service service,
+            HTTPResponseDataDeserializer<T> deserializer) {
+        return executeRemoteCall(() -> {
+            val url = String.format("/ranger/nodes/v1/%s/%s", service.getNamespace(), service.getServiceName());
+
+            log.debug("Refreshing the node list from url {}", url);
+            val httpUrl = new HttpUrl.Builder()
+                    .scheme(config.isSecure() ? "https" : "http")
+                    .host(config.getHost())
+                    .port(config.getPort() == 0 ? defaultPort() : config.getPort())
+                    .encodedPath(url)
+                    .build();
+            val request = new Request.Builder()
+                    .url(httpUrl)
+                    .get()
+                    .build();
+
+            try (val response = httpClient.newCall(request).execute()) {
+                if (response.isSuccessful()) {
+                    return parseNodeList(deserializer, response, httpUrl);
+                }
+                else {
+                    throw new HttpCommunicationException("HTTP call failed. url: " + httpUrl + " status: " + response.code());
+                }
+            }
+            catch (Exception e) {
+                throw new HttpCommunicationException("Error getting node data from the http endpoint: " + httpUrl +
+                                                             ". Error: " + e.getMessage());
+            }
+        });
+    }
+
+    @Override
+    public void close() throws Exception {
+
+    }
+
+    private <U> U executeRemoteCall(Supplier<U> executor) {
+        upstreamAvailable.set(true);
+        try {
+            return executor.get();
+        }
+        catch (HttpCommunicationException e) {
+            upstreamAvailable.set(false);
+            throw e;
+        }
+    }
+
+    private int defaultPort() {
+        return config.isSecure()
+               ? 443
+               : 80;
+    }
+
+    private Set<Service> parseServices(Response response, HttpUrl httpUrl) {
+        try (val body = response.body()) {
+            if (null == body) {
+                throw new HttpCommunicationException("Empty response body from: " + httpUrl);
+            }
+            else {
+                val bytes = body.bytes();
+                val serviceDataSourceResponse = mapper.readValue(bytes, ServiceDataSourceResponse.class);
+                if (serviceDataSourceResponse.valid()) {
+                    return serviceDataSourceResponse.getData();
+                }
+                else {
+                    throw new HttpCommunicationException(
+                            "Http call to returned a failure response. Url:" + httpUrl + " data: " + serviceDataSourceResponse);
+                }
+            }
+        }
+        catch (Exception e) {
+            throw new HttpCommunicationException(
+                    "Error reading data from server. Url: " + httpUrl + "Error: " + e.getMessage());
+        }
+    }
+
+    private static <T> List<ServiceNode<T>> parseNodeList(
+            HTTPResponseDataDeserializer<T> deserializer,
+            Response response,
+            HttpUrl httpUrl) {
+        try (val body = response.body()) {
+            if (null == body) {
+                log.warn("HTTP call to {} returned empty body", httpUrl);
+                throw new HttpCommunicationException("Empty response received for call to " + httpUrl);
+            }
+            else {
+                val bytes = body.bytes();
+                val serviceNodesResponse = deserializer.deserialize(bytes);
+                if (serviceNodesResponse.valid()) {
+                    return serviceNodesResponse.getData();
+                }
+                else {
+                    throw new HttpCommunicationException(
+                            "Http call returned null nodes for url: " + httpUrl + " response: " + serviceNodesResponse);
+                }
+            }
+        }
+        catch (Exception e) {
+            throw new HttpCommunicationException(
+                    "Error parsing node data from server. Url: " + httpUrl + "Error: " + e.getMessage());
+        }
+    }
+}

--- a/ranger-http/src/main/java/io/appform/ranger/http/servicefinder/HttpCommunicationException.java
+++ b/ranger-http/src/main/java/io/appform/ranger/http/servicefinder/HttpCommunicationException.java
@@ -14,15 +14,16 @@
  * limitations under the License.
  */
 
-package io.appform.ranger.drove.common;
+package io.appform.ranger.http.servicefinder;
 
 import io.appform.ranger.core.exceptions.CommunicationException;
 
 /**
- * Thrown in case there is an issue communicating with the drove upstream.
+ * Thrown in case there is an issue communicating with the HTTP upstream.
+
  */
-public class DroveCommunicationException extends CommunicationException {
-    public DroveCommunicationException(final String message) {
+public class HttpCommunicationException extends CommunicationException {
+    public HttpCommunicationException(final String message) {
         super(message);
     }
 }

--- a/ranger-http/src/main/java/io/appform/ranger/http/servicefinder/HttpCommunicator.java
+++ b/ranger-http/src/main/java/io/appform/ranger/http/servicefinder/HttpCommunicator.java
@@ -14,15 +14,26 @@
  * limitations under the License.
  */
 
-package io.appform.ranger.drove.common;
+package io.appform.ranger.http.servicefinder;
 
-import io.appform.ranger.core.exceptions.CommunicationException;
+import io.appform.ranger.core.model.Service;
+import io.appform.ranger.core.model.ServiceNode;
+import io.appform.ranger.http.serde.HTTPResponseDataDeserializer;
+import okhttp3.OkHttpClient;
+
+import java.util.List;
+import java.util.Set;
 
 /**
- * Thrown in case there is an issue communicating with the drove upstream.
+ * Interface for communicator to upstream
  */
-public class DroveCommunicationException extends CommunicationException {
-    public DroveCommunicationException(final String message) {
-        super(message);
-    }
+public interface HttpCommunicator<T> extends AutoCloseable {
+    boolean healthy();
+
+    Set<Service> services();
+
+    List<ServiceNode<T>> listNodes(final Service service,
+                                   HTTPResponseDataDeserializer<T> deserializer);
+
+    OkHttpClient getHttpClient();
 }

--- a/ranger-http/src/main/java/io/appform/ranger/http/servicefinder/HttpShardedServiceFinderBuilder.java
+++ b/ranger-http/src/main/java/io/appform/ranger/http/servicefinder/HttpShardedServiceFinderBuilder.java
@@ -23,7 +23,6 @@ import io.appform.ranger.core.model.Service;
 import io.appform.ranger.http.config.HttpClientConfig;
 import io.appform.ranger.http.serde.HTTPResponseDataDeserializer;
 import io.appform.ranger.http.utils.RangerHttpUtils;
-import okhttp3.OkHttpClient;
 
 import java.util.Objects;
 
@@ -34,7 +33,7 @@ public class HttpShardedServiceFinderBuilder<T> extends SimpleShardedServiceFind
 
     private HttpClientConfig clientConfig;
     private ObjectMapper mapper;
-    private OkHttpClient httpClient;
+    private HttpCommunicator<T> httpCommunicator;
 
     public HttpShardedServiceFinderBuilder<T> withClientConfig(final HttpClientConfig clientConfig) {
         this.clientConfig = clientConfig;
@@ -46,8 +45,8 @@ public class HttpShardedServiceFinderBuilder<T> extends SimpleShardedServiceFind
         return this;
     }
 
-    public HttpShardedServiceFinderBuilder<T> withHttpClient(final OkHttpClient httpClient){
-        this.httpClient = httpClient;
+    public HttpShardedServiceFinderBuilder<T> withHttpCommunicator(final HttpCommunicator<T> httpCommunicator){
+        this.httpCommunicator = httpCommunicator;
         return this;
     }
 
@@ -58,9 +57,9 @@ public class HttpShardedServiceFinderBuilder<T> extends SimpleShardedServiceFind
 
     @Override
     protected NodeDataSource<T, HTTPResponseDataDeserializer<T>> dataSource(Service service) {
-        return new HttpNodeDataSource<>(service, clientConfig, mapper,
-                                        Objects.requireNonNullElseGet(httpClient,
-                                                                      () -> RangerHttpUtils.httpClient(clientConfig)));
+        return new HttpNodeDataSource<>(service, clientConfig,
+                                        Objects.requireNonNullElseGet(httpCommunicator,
+                                                                      () -> RangerHttpUtils.httpClient(clientConfig, mapper)));
     }
 
 }

--- a/ranger-http/src/main/java/io/appform/ranger/http/servicefinder/HttpUnshardedServiceFinderBuilider.java
+++ b/ranger-http/src/main/java/io/appform/ranger/http/servicefinder/HttpUnshardedServiceFinderBuilider.java
@@ -23,7 +23,6 @@ import io.appform.ranger.core.model.Service;
 import io.appform.ranger.http.config.HttpClientConfig;
 import io.appform.ranger.http.serde.HTTPResponseDataDeserializer;
 import io.appform.ranger.http.utils.RangerHttpUtils;
-import okhttp3.OkHttpClient;
 
 import java.util.Objects;
 
@@ -32,7 +31,7 @@ public class HttpUnshardedServiceFinderBuilider<T>
 
     private HttpClientConfig clientConfig;
     private ObjectMapper mapper;
-    private OkHttpClient httpClient;
+    private HttpCommunicator<T> httpClient;
 
     public HttpUnshardedServiceFinderBuilider<T> withClientConfig(final HttpClientConfig clientConfig) {
         this.clientConfig = clientConfig;
@@ -44,7 +43,7 @@ public class HttpUnshardedServiceFinderBuilider<T>
         return this;
     }
 
-    public HttpUnshardedServiceFinderBuilider<T> withHttpClient(final OkHttpClient httpClient) {
+    public HttpUnshardedServiceFinderBuilider<T> withHttpClient(final HttpCommunicator<T> httpClient) {
         this.httpClient = httpClient;
         return this;
     }
@@ -56,9 +55,9 @@ public class HttpUnshardedServiceFinderBuilider<T>
 
     @Override
     protected NodeDataSource<T, HTTPResponseDataDeserializer<T>> dataSource(Service service) {
-        return new HttpNodeDataSource<>(service, clientConfig, mapper,
+        return new HttpNodeDataSource<>(service, clientConfig,
                                         Objects.requireNonNullElseGet(httpClient,
-                                                                      () -> RangerHttpUtils.httpClient(clientConfig)));
+                                                                      () -> RangerHttpUtils.httpClient(clientConfig, mapper)));
     }
 
 }

--- a/ranger-http/src/main/java/io/appform/ranger/http/servicefinderhub/HttpShardedServiceFinderFactory.java
+++ b/ranger-http/src/main/java/io/appform/ranger/http/servicefinderhub/HttpShardedServiceFinderFactory.java
@@ -24,15 +24,15 @@ import io.appform.ranger.core.model.ServiceNodeSelector;
 import io.appform.ranger.core.model.ShardSelector;
 import io.appform.ranger.http.config.HttpClientConfig;
 import io.appform.ranger.http.serde.HTTPResponseDataDeserializer;
+import io.appform.ranger.http.servicefinder.HttpCommunicator;
 import io.appform.ranger.http.servicefinder.HttpShardedServiceFinderBuilder;
 import lombok.Builder;
 import lombok.val;
-import okhttp3.OkHttpClient;
 
 public class HttpShardedServiceFinderFactory <T> implements ServiceFinderFactory<T, MapBasedServiceRegistry<T>> {
 
     private final HttpClientConfig clientConfig;
-    private final OkHttpClient httpClient;
+    private final HttpCommunicator<T> httpClient;
     private final ObjectMapper mapper;
     private final HTTPResponseDataDeserializer<T> deserializer;
     private final ShardSelector<T, MapBasedServiceRegistry<T>> shardSelector;
@@ -41,7 +41,8 @@ public class HttpShardedServiceFinderFactory <T> implements ServiceFinderFactory
 
     @Builder
     public HttpShardedServiceFinderFactory(
-            HttpClientConfig httpClientConfig, OkHttpClient httpClient,
+            HttpClientConfig httpClientConfig,
+            HttpCommunicator<T> httpClient,
             ObjectMapper mapper,
             HTTPResponseDataDeserializer<T> deserializer,
             ShardSelector<T, MapBasedServiceRegistry<T>> shardSelector,
@@ -61,8 +62,8 @@ public class HttpShardedServiceFinderFactory <T> implements ServiceFinderFactory
     public ServiceFinder<T, MapBasedServiceRegistry<T>> buildFinder(Service service) {
         val serviceFinder = new HttpShardedServiceFinderBuilder<T>()
                 .withClientConfig(clientConfig)
-                .withHttpClient(httpClient)
                 .withObjectMapper(mapper)
+                .withHttpCommunicator(httpClient)
                 .withDeserializer(deserializer)
                 .withNamespace(service.getNamespace())
                 .withServiceName(service.getServiceName())

--- a/ranger-http/src/main/java/io/appform/ranger/http/servicefinderhub/HttpUnshardedServiceFinderFactory.java
+++ b/ranger-http/src/main/java/io/appform/ranger/http/servicefinderhub/HttpUnshardedServiceFinderFactory.java
@@ -24,16 +24,16 @@ import io.appform.ranger.core.model.ServiceNodeSelector;
 import io.appform.ranger.core.model.ShardSelector;
 import io.appform.ranger.http.config.HttpClientConfig;
 import io.appform.ranger.http.serde.HTTPResponseDataDeserializer;
+import io.appform.ranger.http.servicefinder.HttpCommunicator;
 import io.appform.ranger.http.servicefinder.HttpUnshardedServiceFinderBuilider;
 import lombok.Builder;
 import lombok.val;
-import okhttp3.OkHttpClient;
 
 public class HttpUnshardedServiceFinderFactory<T> implements ServiceFinderFactory<T, ListBasedServiceRegistry<T>> {
 
     private final HttpClientConfig clientConfig;
     private final ObjectMapper mapper;
-    private final OkHttpClient httpClient;
+    private final HttpCommunicator<T> httpClient;
     private final HTTPResponseDataDeserializer<T> deserializer;
     private final ShardSelector<T, ListBasedServiceRegistry<T>> shardSelector;
     private final ServiceNodeSelector<T> nodeSelector;
@@ -42,12 +42,12 @@ public class HttpUnshardedServiceFinderFactory<T> implements ServiceFinderFactor
     @Builder
     public HttpUnshardedServiceFinderFactory(
             HttpClientConfig httpClientConfig,
-            ObjectMapper mapper, OkHttpClient httpClient,
+            ObjectMapper mapper,
+            HttpCommunicator<T> httpClient,
             HTTPResponseDataDeserializer<T> deserializer,
             ShardSelector<T, ListBasedServiceRegistry<T>> shardSelector,
             ServiceNodeSelector<T> nodeSelector,
-            int nodeRefreshIntervalMs)
-    {
+            int nodeRefreshIntervalMs) {
         this.clientConfig = httpClientConfig;
         this.mapper = mapper;
         this.httpClient = httpClient;

--- a/ranger-http/src/main/java/io/appform/ranger/http/serviceprovider/HttpNodeDataSink.java
+++ b/ranger-http/src/main/java/io/appform/ranger/http/serviceprovider/HttpNodeDataSink.java
@@ -26,10 +26,10 @@ import io.appform.ranger.http.common.HttpNodeDataStoreConnector;
 import io.appform.ranger.http.config.HttpClientConfig;
 import io.appform.ranger.http.model.ServiceRegistrationResponse;
 import io.appform.ranger.http.serde.HttpRequestDataSerializer;
+import io.appform.ranger.http.servicefinder.HttpCommunicator;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import okhttp3.HttpUrl;
-import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.RequestBody;
 
@@ -40,10 +40,12 @@ import java.util.Optional;
 public class HttpNodeDataSink<T, S extends HttpRequestDataSerializer<T>> extends HttpNodeDataStoreConnector<T> implements NodeDataSink<T, S> {
 
     private final Service service;
+    private final ObjectMapper mapper;
 
-    public HttpNodeDataSink(Service service, HttpClientConfig config, ObjectMapper mapper, OkHttpClient httpClient) {
-        super(config, mapper, httpClient);
+    public HttpNodeDataSink(Service service, HttpClientConfig config, ObjectMapper mapper, HttpCommunicator<T> httpClient) {
+        super(config, httpClient);
         this.service = service;
+        this.mapper = mapper;
     }
 
     @Override
@@ -77,7 +79,7 @@ public class HttpNodeDataSink<T, S extends HttpRequestDataSerializer<T>> extends
                 .url(httpUrl)
                 .post(requestBody)
                 .build();
-        try (val response = httpClient.newCall(request).execute()) {
+        try (val response = httpCommunicator.getHttpClient().newCall(request).execute()) {
             if (response.isSuccessful()) {
                 try (val body = response.body()) {
                     if (null == body) {

--- a/ranger-http/src/main/java/io/appform/ranger/http/serviceprovider/HttpShardedServiceProviderBuilder.java
+++ b/ranger-http/src/main/java/io/appform/ranger/http/serviceprovider/HttpShardedServiceProviderBuilder.java
@@ -22,9 +22,9 @@ import io.appform.ranger.core.serviceprovider.BaseServiceProviderBuilder;
 import io.appform.ranger.core.serviceprovider.ServiceProvider;
 import io.appform.ranger.http.config.HttpClientConfig;
 import io.appform.ranger.http.serde.HttpRequestDataSerializer;
+import io.appform.ranger.http.servicefinder.HttpCommunicator;
 import io.appform.ranger.http.utils.RangerHttpUtils;
 import lombok.extern.slf4j.Slf4j;
-import okhttp3.OkHttpClient;
 
 import java.util.Objects;
 
@@ -33,7 +33,7 @@ public class HttpShardedServiceProviderBuilder<T> extends BaseServiceProviderBui
 
     private HttpClientConfig clientConfig;
     private ObjectMapper mapper;
-    private OkHttpClient httpClient;
+    private HttpCommunicator<T> httpClient;
 
     public HttpShardedServiceProviderBuilder<T> withClientConfiguration(final HttpClientConfig clientConfig) {
         this.clientConfig = clientConfig;
@@ -45,7 +45,7 @@ public class HttpShardedServiceProviderBuilder<T> extends BaseServiceProviderBui
         return this;
     }
 
-    public HttpShardedServiceProviderBuilder<T> withHttpClient(final OkHttpClient httpClient) {
+    public HttpShardedServiceProviderBuilder<T> withHttpClient(final HttpCommunicator<T> httpClient) {
         this.httpClient = httpClient;
         return this;
     }
@@ -59,6 +59,6 @@ public class HttpShardedServiceProviderBuilder<T> extends BaseServiceProviderBui
     protected NodeDataSink<T, HttpRequestDataSerializer<T>> dataSink(Service service) {
         return new HttpNodeDataSink<>(service, clientConfig, mapper,
                                       Objects.requireNonNullElseGet(httpClient,
-                                                                    () -> RangerHttpUtils.httpClient(clientConfig)));
+                                                                    () -> RangerHttpUtils.httpClient(clientConfig, mapper)));
     }
 }

--- a/ranger-http/src/main/java/io/appform/ranger/http/utils/RangerHttpUtils.java
+++ b/ranger-http/src/main/java/io/appform/ranger/http/utils/RangerHttpUtils.java
@@ -16,7 +16,10 @@
 
 package io.appform.ranger.http.utils;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.appform.ranger.http.config.HttpClientConfig;
+import io.appform.ranger.http.servicefinder.HttpApiCommunicator;
+import io.appform.ranger.http.servicefinder.HttpCommunicator;
 import lombok.experimental.UtilityClass;
 import lombok.extern.slf4j.Slf4j;
 import okhttp3.ConnectionPool;
@@ -30,17 +33,22 @@ import java.util.concurrent.TimeUnit;
 @UtilityClass
 @Slf4j
 public class RangerHttpUtils {
-    public static OkHttpClient httpClient(final HttpClientConfig config) {
+    public static <T> HttpCommunicator<T> httpClient(
+            final HttpClientConfig config,
+            final ObjectMapper mapper) {
         log.info("Creating http client for {}:{}", config.getHost(), config.getPort());
-        return new OkHttpClient.Builder()
-                .callTimeout(config.getOperationTimeoutMs() == 0
-                             ? 3000
-                             : config.getOperationTimeoutMs(), TimeUnit.MILLISECONDS)
-                .connectTimeout(config.getConnectionTimeoutMs() == 0
-                                ? 3000
-                                : config.getConnectionTimeoutMs(), TimeUnit.MILLISECONDS)
-                .followRedirects(true)
-                .connectionPool(new ConnectionPool(1, 30, TimeUnit.SECONDS))
-                .build();
+        return new HttpApiCommunicator<>(
+                new OkHttpClient.Builder()
+                        .callTimeout(config.getOperationTimeoutMs() == 0
+                                     ? 3000
+                                     : config.getOperationTimeoutMs(), TimeUnit.MILLISECONDS)
+                        .connectTimeout(config.getConnectionTimeoutMs() == 0
+                                        ? 3000
+                                        : config.getConnectionTimeoutMs(), TimeUnit.MILLISECONDS)
+                        .followRedirects(true)
+                        .connectionPool(new ConnectionPool(1, 30, TimeUnit.SECONDS))
+                        .build(),
+                config,
+                mapper);
     }
 }

--- a/ranger-http/src/test/java/io/appform/ranger/http/common/HttpNodeDataStoreConnectorTest.java
+++ b/ranger-http/src/test/java/io/appform/ranger/http/common/HttpNodeDataStoreConnectorTest.java
@@ -31,8 +31,8 @@ class HttpNodeDataStoreConnectorTest {
                 .host("localhost-1")
                 .port(80)
                 .build();
-        val httpNodeDataStoreConnector = new HttpNodeDataStoreConnector<>(httpClientConfig, objectMapper,
-                                                                          RangerHttpUtils.httpClient(httpClientConfig));
+        val httpNodeDataStoreConnector = new HttpNodeDataStoreConnector<>(httpClientConfig,
+                                                                          RangerHttpUtils.httpClient(httpClientConfig, objectMapper));
         Assertions.assertNotNull(httpNodeDataStoreConnector);
         Assertions.assertTrue(httpNodeDataStoreConnector.isActive());
     }

--- a/ranger-http/src/test/java/io/appform/ranger/http/servicefinderhub/HttpServiceDataSourceTest.java
+++ b/ranger-http/src/test/java/io/appform/ranger/http/servicefinderhub/HttpServiceDataSourceTest.java
@@ -55,7 +55,7 @@ class HttpServiceDataSourceTest {
                 .connectionTimeoutMs(30_000)
                 .operationTimeoutMs(30_000)
                 .build();
-        val httpServiceDataSource = new HttpServiceDataSource<>(clientConfig, MAPPER, RangerHttpUtils.httpClient(clientConfig));
+        val httpServiceDataSource = new HttpServiceDataSource<>(clientConfig, RangerHttpUtils.httpClient(clientConfig, MAPPER));
         val services = httpServiceDataSource.services();
         Assertions.assertNotNull(services);
         Assertions.assertFalse(services.isEmpty());

--- a/ranger-hub-server-bundle/pom.xml
+++ b/ranger-hub-server-bundle/pom.xml
@@ -39,10 +39,6 @@
 
     <artifactId>ranger-hub-server-bundle</artifactId>
 
-    <properties>
-        <dropwizard.version>2.0.23</dropwizard.version>
-    </properties>
-
   <dependencies>
     <dependency>
       <groupId>io.appform.ranger</groupId>

--- a/ranger-hub-server-bundle/src/main/java/io/appform/ranger/hub/server/bundle/RangerHubServerBundle.java
+++ b/ranger-hub-server-bundle/src/main/java/io/appform/ranger/hub/server/bundle/RangerHubServerBundle.java
@@ -128,7 +128,7 @@ public abstract class RangerHubServerBundle<U extends Configuration>
                     .namespace(namespace)
                     .mapper(getMapper())
                     .clientConfig(httpClientConfig)
-                    .httpClient(RangerHttpUtils.httpClient(httpClientConfig))
+                    .httpClient(RangerHttpUtils.httpClient(httpClientConfig, getMapper()))
                     .serviceRefreshDurationMs(httpConfiguration.getServiceRefreshDurationMs())
                     .hubRefreshDurationMs(httpConfiguration.getServiceRefreshDurationMs())
                     .nodeRefreshTimeMs(httpConfiguration.getNodeRefreshTimeMs())

--- a/ranger-hub-server-bundle/src/main/java/io/appform/ranger/hub/server/bundle/RangerHubServerBundle.java
+++ b/ranger-hub-server-bundle/src/main/java/io/appform/ranger/hub/server/bundle/RangerHubServerBundle.java
@@ -107,6 +107,7 @@ public abstract class RangerHubServerBundle<U extends Configuration>
                     .disablePushUpdaters(zkConfiguration.isDisablePushUpdaters())
                     .mapper(getMapper())
                     .serviceRefreshDurationMs(zkConfiguration.getServiceRefreshDurationMs())
+                    .hubRefreshDurationMs(zkConfiguration.getServiceRefreshDurationMs())
                     .nodeRefreshTimeMs(zkConfiguration.getNodeRefreshTimeMs())
                     .deserializer(data -> {
                         try {
@@ -129,6 +130,7 @@ public abstract class RangerHubServerBundle<U extends Configuration>
                     .clientConfig(httpClientConfig)
                     .httpClient(RangerHttpUtils.httpClient(httpClientConfig))
                     .serviceRefreshDurationMs(httpConfiguration.getServiceRefreshDurationMs())
+                    .hubRefreshDurationMs(httpConfiguration.getServiceRefreshDurationMs())
                     .nodeRefreshTimeMs(httpConfiguration.getNodeRefreshTimeMs())
                     .deserializer(data -> {
                         try {
@@ -155,6 +157,7 @@ public abstract class RangerHubServerBundle<U extends Configuration>
                     .clientConfig(droveConfig)
                     .droveCommunicator(droveCommunicator)
                     .serviceRefreshDurationMs(droveUpstreamConfiguration.getServiceRefreshDurationMs())
+                    .hubRefreshDurationMs(droveUpstreamConfiguration.getServiceRefreshDurationMs())
                     .nodeRefreshTimeMs(droveUpstreamConfiguration.getNodeRefreshTimeMs())
                     .deserializer(new DroveResponseDataDeserializer<>() {
                         @Override

--- a/ranger-hub-server-bundle/src/main/java/io/appform/ranger/hub/server/bundle/healthcheck/RangerHealthCheck.java
+++ b/ranger-hub-server-bundle/src/main/java/io/appform/ranger/hub/server/bundle/healthcheck/RangerHealthCheck.java
@@ -16,11 +16,9 @@
 package io.appform.ranger.hub.server.bundle.healthcheck;
 
 import com.codahale.metrics.health.HealthCheck;
-import javax.inject.Singleton;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.curator.framework.CuratorFramework;
 
-@Singleton
 @Slf4j
 public class RangerHealthCheck extends HealthCheck {
 

--- a/ranger-hub-server-bundle/src/main/java/io/appform/ranger/hub/server/bundle/lifecycle/CuratorLifecycle.java
+++ b/ranger-hub-server-bundle/src/main/java/io/appform/ranger/hub/server/bundle/lifecycle/CuratorLifecycle.java
@@ -17,13 +17,12 @@ package io.appform.ranger.hub.server.bundle.lifecycle;
 
 import io.appform.ranger.common.server.ShardInfo;
 import io.appform.ranger.core.signals.Signal;
-import java.util.Collections;
-import javax.inject.Singleton;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.curator.framework.CuratorFramework;
 
+import java.util.Collections;
+
 @Slf4j
-@Singleton
 public class CuratorLifecycle extends Signal<ShardInfo> {
 
   private final CuratorFramework curatorFramework;

--- a/ranger-server/pom.xml
+++ b/ranger-server/pom.xml
@@ -27,6 +27,11 @@
 
     <artifactId>ranger-server</artifactId>
 
+    <properties>
+        <jakarta.inject-api.version>2.0.1</jakarta.inject-api.version>
+        <dw-guicey.version>5.10.2</dw-guicey.version>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>io.appform.ranger</groupId>
@@ -36,6 +41,16 @@
         <dependency>
             <groupId>io.dropwizard</groupId>
             <artifactId>dropwizard-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.inject</groupId>
+            <artifactId>jakarta.inject-api</artifactId>
+            <version>${jakarta.inject-api.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>ru.vyarus</groupId>
+            <artifactId>dropwizard-guicey</artifactId>
+            <version>${dw-guicey.version}</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
- Introduced communication execption
- Introduced communicator for http
- Introduced circuit breakers for drove and http
- Staleness check is done centrally at ServiceRegistryUpdater
- Bugfix: If upstream is inactive, the refresher will override timestamps with current time so that all nodes don't go stale in one minute
- Performance optimization: Introduced ForkJoinPool for hub refresh. Default pool of 20 or processor count whichever is higher. Significant improvement in startup time.
- - Dropwizard version upgrade to 2.1.12
