### PR TITLE
Fixing race condition while starting service finder hub.

### DIFF
--- a/ranger-http/src/main/java/io/appform/ranger/http/utils/RangerHttpUtils.java
+++ b/ranger-http/src/main/java/io/appform/ranger/http/utils/RangerHttpUtils.java
@@ -45,6 +45,12 @@ public class RangerHttpUtils {
                         .connectTimeout(config.getConnectionTimeoutMs() == 0
                                         ? 3000
                                         : config.getConnectionTimeoutMs(), TimeUnit.MILLISECONDS)
+                        .readTimeout(config.getOperationTimeoutMs() == 0
+                                ? 3000
+                                : config.getOperationTimeoutMs(), TimeUnit.MILLISECONDS)
+                        .writeTimeout(config.getOperationTimeoutMs() == 0
+                                ? 3000
+                                : config.getOperationTimeoutMs(), TimeUnit.MILLISECONDS)
                         .followRedirects(true)
                         .connectionPool(new ConnectionPool(1, 30, TimeUnit.SECONDS))
                         .build(),

--- a/ranger-server/src/main/resources/local.yml
+++ b/ranger-server/src/main/resources/local.yml
@@ -1,0 +1,41 @@
+ranger:
+  namespace: mynamespace
+  upstreams:
+    - type: HTTP
+      nodeRefreshTimeMs: 5000
+      serviceRefreshTimeoutMs: 300000
+      hubStartTimeoutMs: 210000
+      httpClientConfigs:
+        - host: localhost
+          port: 80
+    - type: ZK
+      nodeRefreshTimeMs: 5000
+      serviceRefreshTimeoutMs: 3000
+      hubStartTimeoutMs: 5000
+      zookeepers: [ "localhost:2181" ]
+      disablePushUpdaters: true
+
+
+server:
+  maxThreads: 1024
+  minThreads: 1024
+  applicationConnectors:
+    - type: http
+      port: 18080
+  adminConnectors:
+    - type: http
+      port: 18081
+  applicationContextPath: /
+  requestLog:
+    appenders:
+      - type: console
+        timeZone: IST
+
+logging:
+  level: INFO
+
+  appenders:
+    - type: console
+      threshold: INFO
+      timeZone: IST
+      logFormat: "%(%-5level) [%date] [%thread] [%logger{0}]: %message%n"


### PR DESCRIPTION
- Changed the order in which updateAvailable was triggered in the ServiceFinderHub: In some race condition when monitor function was triggered and acquired the lock, the updateAvailable method was blocked, which is running in the main thread resulting in control not reaching till waitTillHubIsReady and the actual timeout was not honoured. Now moved the updateAvailable above the signal updateAvailable.
- Adding local.yml file: It will help in giving template for config file as well as for locally running the ranger server.
- Explicitly setting the readTime and write Timeout in OkHttpClient: These timeouts were picked as default and not honouring the operation timeout.
- Added waitStrategy in waitTillServiceIsReady