### PR TITLE
Improve service finder hub startup time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,6 @@ All notable changes to this project will be documented in this file.
 
 ## [1.1-RC4]
 - Remove WaitStrategy in the Retryer used to check if ServiceRegistry is refreshed during ServiceRegistryUpdater startup
-- Remove service-hub-refresh-timer ScheduledSignal because there's already one ScheduledSignal service-hub-updater used in ServiceFinderHub
 
 ## [1.1-RC3]
 - Execute updateRegistry operation in async inside  ServiceFinderHub so that main thread reaches till waitTillHubIsReady instead of waiting for lock release and hubStartTimeoutMs is honoured as expected

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [1.1-RC4]
+- Remove WaitStrategy in the Retryer used to check if ServiceRegistry is refreshed during ServiceRegistryUpdater startup
+- Remove service-hub-refresh-timer ScheduledSignal because there's already one ScheduledSignal service-hub-updater used in ServiceFinderHub
+
 ## [1.1-RC3]
 - Execute updateRegistry operation in async inside  ServiceFinderHub so that main thread reaches till waitTillHubIsReady instead of waiting for lock release and hubStartTimeoutMs is honoured as expected
 - Setting the read timeout and write timeout in OkHttpClient same as operation timeout given in HttpClientConfig

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <groupId>io.appform.ranger</groupId>
     <artifactId>ranger</artifactId>
     <packaging>pom</packaging>
-    <version>1.1-RC3</version>
+    <version>1.1-RC4</version>
     <name>Ranger</name>
     <url>https://github.com/appform-io/ranger</url>
     <description>Service Discovery for Java</description>

--- a/ranger-client/pom.xml
+++ b/ranger-client/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>ranger</artifactId>
         <groupId>io.appform.ranger</groupId>
-        <version>1.1-RC3</version>
+        <version>1.1-RC4</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/ranger-core/pom.xml
+++ b/ranger-core/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>ranger</artifactId>
         <groupId>io.appform.ranger</groupId>
-        <version>1.1-RC3</version>
+        <version>1.1-RC4</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/ranger-core/src/main/java/io/appform/ranger/core/finder/serviceregistry/ServiceRegistryUpdater.java
+++ b/ranger-core/src/main/java/io/appform/ranger/core/finder/serviceregistry/ServiceRegistryUpdater.java
@@ -75,7 +75,6 @@ public class ServiceRegistryUpdater<T, D extends Deserializer<T>> {
             RetryerBuilder.<Boolean>newBuilder()
                     .retryIfResult(r -> null == r || !r)
                     .retryIfException()
-                    .withWaitStrategy(WaitStrategies.fixedWait(1, TimeUnit.SECONDS))
                     .build()
                     .call(serviceRegistry::isRefreshed);
         }

--- a/ranger-core/src/main/java/io/appform/ranger/core/finderhub/ServiceFinderHub.java
+++ b/ranger-core/src/main/java/io/appform/ranger/core/finderhub/ServiceFinderHub.java
@@ -84,9 +84,9 @@ public class ServiceFinderHub<T, R extends ServiceRegistry<T>> {
     public ServiceFinderHub(
             ServiceDataSource serviceDataSource,
             ServiceFinderFactory<T, R> finderFactory
-                           ) {
+    ) {
         this(serviceDataSource, finderFactory,
-                HubConstants.SERVICE_REFRESH_TIMEOUT_MS, HubConstants.HUB_START_TIMEOUT_MS, 5_000, Set.of());
+                HubConstants.SERVICE_REFRESH_TIMEOUT_MS, HubConstants.HUB_START_TIMEOUT_MS, Set.of());
     }
 
     public ServiceFinderHub(
@@ -94,21 +94,15 @@ public class ServiceFinderHub<T, R extends ServiceRegistry<T>> {
             ServiceFinderFactory<T, R> finderFactory,
             long serviceRefreshTimeoutMs,
             long hubStartTimeoutMs,
-            long refreshTimeIntervalMs,
             final Set<String> excludedServices) {
         this.serviceDataSource = serviceDataSource;
         this.finderFactory = finderFactory;
         this.serviceRefreshTimeoutMs = serviceRefreshTimeoutMs == 0 ? HubConstants.SERVICE_REFRESH_TIMEOUT_MS : serviceRefreshTimeoutMs;
         this.hubStartTimeoutMs = hubStartTimeoutMs == 0 ? HubConstants.HUB_START_TIMEOUT_MS : hubStartTimeoutMs;
-        final ScheduledSignal<Void> refreshSignal = new ScheduledSignal<>("service-hub-updater",
-                                                                          () -> null,
-                                                                          Collections.emptyList(),
-                                                                          refreshTimeIntervalMs);
-        this.refreshSignals.add(refreshSignal);
-        this.getStartSignal()
-            .registerConsumer(x -> refreshSignal.start());
-        this.getStopSignal()
-            .registerConsumer(x -> refreshSignal.stop());
+        this.refreshSignals.add(new ScheduledSignal<>("service-hub-updater",
+                () -> null,
+                Collections.emptyList(),
+                10_000));
         this.refresherPool = createRefresherPool();
         this.excludedServices = Objects.requireNonNullElseGet(excludedServices, Set::of);
     }

--- a/ranger-core/src/main/java/io/appform/ranger/core/finderhub/ServiceFinderHub.java
+++ b/ranger-core/src/main/java/io/appform/ranger/core/finderhub/ServiceFinderHub.java
@@ -86,8 +86,7 @@ public class ServiceFinderHub<T, R extends ServiceRegistry<T>> {
             ServiceFinderFactory<T, R> finderFactory
                            ) {
         this(serviceDataSource, finderFactory,
-                HubConstants.SERVICE_REFRESH_TIMEOUT_MS, HubConstants.HUB_START_TIMEOUT_MS, 5_000,
-            Set.of());
+                HubConstants.SERVICE_REFRESH_TIMEOUT_MS, HubConstants.HUB_START_TIMEOUT_MS, 5_000, Set.of());
     }
 
     public ServiceFinderHub(
@@ -102,9 +101,9 @@ public class ServiceFinderHub<T, R extends ServiceRegistry<T>> {
         this.serviceRefreshTimeoutMs = serviceRefreshTimeoutMs == 0 ? HubConstants.SERVICE_REFRESH_TIMEOUT_MS : serviceRefreshTimeoutMs;
         this.hubStartTimeoutMs = hubStartTimeoutMs == 0 ? HubConstants.HUB_START_TIMEOUT_MS : hubStartTimeoutMs;
         final ScheduledSignal<Void> refreshSignal = new ScheduledSignal<>("service-hub-updater",
-                                                                            () -> null,
-                                                                            Collections.emptyList(),
-                                                                            refreshTimeIntervalMs);
+                                                                          () -> null,
+                                                                          Collections.emptyList(),
+                                                                          refreshTimeIntervalMs);
         this.refreshSignals.add(refreshSignal);
         this.getStartSignal()
             .registerConsumer(x -> refreshSignal.start());

--- a/ranger-core/src/main/java/io/appform/ranger/core/finderhub/ServiceFinderHubBuilder.java
+++ b/ranger-core/src/main/java/io/appform/ranger/core/finderhub/ServiceFinderHubBuilder.java
@@ -93,21 +93,14 @@ public abstract class ServiceFinderHubBuilder<T, R extends ServiceRegistry<T>> {
         Preconditions.checkNotNull(serviceFinderFactory, "Provide a non-null service finder factory");
 
         val hub = new ServiceFinderHub<>(serviceDataSource, serviceFinderFactory, serviceRefreshTimeoutMs,
-                hubStartTimeoutMs, excludedServices);
-        final ScheduledSignal<Void> refreshSignal = new ScheduledSignal<>("service-hub-refresh-timer",
-                                                                          () -> null,
-                                                                          Collections.emptyList(),
-                                                                          refreshFrequencyMs);
-        hub.registerUpdateSignal(refreshSignal);
+                hubStartTimeoutMs, refreshFrequencyMs, excludedServices);
         extraRefreshSignals.forEach(hub::registerUpdateSignal);
 
         hub.getStartSignal()
                 .registerConsumer(x -> serviceDataSource.start())
-                .registerConsumer(x -> refreshSignal.start())
                 .registerConsumers(extraStartSignalConsumers);
         hub.getStopSignal()
                 .registerConsumers(extraStopSignalConsumers)
-                .registerConsumer(x -> refreshSignal.stop())
                 .registerConsumer(x -> serviceDataSource.stop());
         postBuild(hub);
         return hub;

--- a/ranger-core/src/test/java/io/appform/ranger/core/finderhub/ServiceFinderHubTest.java
+++ b/ranger-core/src/test/java/io/appform/ranger/core/finderhub/ServiceFinderHubTest.java
@@ -93,7 +93,7 @@ class ServiceFinderHubTest {
                         .withServiceName(service.getServiceName())
                         .withDeserializer(new Deserializer<TestNodeData>() {})
                         .withSleepDuration(5)
-                        .build(), 1_000, 5_000, Set.of()
+                        .build(), 1_000, 5_000, 5_000, Set.of()
         );
         Assertions.assertThrows(IllegalStateException.class, delayedHub::start);
         val serviceFinderHub = new ServiceFinderHub<>(new DynamicDataSource(Lists.newArrayList(new Service("NS", "SERVICE"))),
@@ -102,7 +102,7 @@ class ServiceFinderHubTest {
                         .withServiceName(service.getServiceName())
                         .withDeserializer(new Deserializer<TestNodeData>() {})
                         .withSleepDuration(1)
-                        .build(), 5_000, 5_000, Set.of()
+                        .build(), 5_000, 5_000, 5_000, Set.of()
         );
         serviceFinderHub.start();
         Assertions.assertTrue(serviceFinderHub.finder(new Service("NS", "SERVICE")).isPresent());

--- a/ranger-core/src/test/java/io/appform/ranger/core/finderhub/ServiceFinderHubTest.java
+++ b/ranger-core/src/test/java/io/appform/ranger/core/finderhub/ServiceFinderHubTest.java
@@ -93,7 +93,7 @@ class ServiceFinderHubTest {
                         .withServiceName(service.getServiceName())
                         .withDeserializer(new Deserializer<TestNodeData>() {})
                         .withSleepDuration(5)
-                        .build(), 1_000, 5_000, 5_000, Set.of()
+                        .build(), 1_000, 5_000, Set.of()
         );
         Assertions.assertThrows(IllegalStateException.class, delayedHub::start);
         val serviceFinderHub = new ServiceFinderHub<>(new DynamicDataSource(Lists.newArrayList(new Service("NS", "SERVICE"))),
@@ -102,7 +102,7 @@ class ServiceFinderHubTest {
                         .withServiceName(service.getServiceName())
                         .withDeserializer(new Deserializer<TestNodeData>() {})
                         .withSleepDuration(1)
-                        .build(), 5_000, 5_000, 5_000, Set.of()
+                        .build(), 5_000, 5_000, Set.of()
         );
         serviceFinderHub.start();
         Assertions.assertTrue(serviceFinderHub.finder(new Service("NS", "SERVICE")).isPresent());
@@ -142,18 +142,18 @@ class ServiceFinderHubTest {
         }
     }
 
-private static class TestServiceFinderHubBuilder extends ServiceFinderHubBuilder<TestNodeData, MapBasedServiceRegistry<TestNodeData>> {
+    private static class TestServiceFinderHubBuilder extends ServiceFinderHubBuilder<TestNodeData, MapBasedServiceRegistry<TestNodeData>> {
 
-    @Override
-    protected void preBuild() {
+        @Override
+        protected void preBuild() {
 
+        }
+
+        @Override
+        protected void postBuild(ServiceFinderHub<TestNodeData, MapBasedServiceRegistry<TestNodeData>> serviceFinderHub) {
+
+        }
     }
-
-    @Override
-    protected void postBuild(ServiceFinderHub<TestNodeData, MapBasedServiceRegistry<TestNodeData>> serviceFinderHub) {
-
-    }
-}
     private static class TestServiceFinderBuilder extends BaseServiceFinderBuilder<TestNodeData, MapBasedServiceRegistry<TestNodeData>, ServiceFinder<TestNodeData, MapBasedServiceRegistry<TestNodeData>>, TestServiceFinderBuilder, Deserializer<TestNodeData>> {
 
         private int finderSleepDurationSeconds = 0;

--- a/ranger-discovery-bundle/pom.xml
+++ b/ranger-discovery-bundle/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>ranger</artifactId>
         <groupId>io.appform.ranger</groupId>
-        <version>1.1-RC3</version>
+        <version>1.1-RC4</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/ranger-drove-client/pom.xml
+++ b/ranger-drove-client/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>ranger</artifactId>
         <groupId>io.appform.ranger</groupId>
-        <version>1.1-RC3</version>
+        <version>1.1-RC4</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/ranger-drove/pom.xml
+++ b/ranger-drove/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>ranger</artifactId>
         <groupId>io.appform.ranger</groupId>
-        <version>1.1-RC3</version>
+        <version>1.1-RC4</version>
     </parent>
     <properties>
         <drove.version>1.30</drove.version>

--- a/ranger-http-client/pom.xml
+++ b/ranger-http-client/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>ranger</artifactId>
         <groupId>io.appform.ranger</groupId>
-        <version>1.1-RC3</version>
+        <version>1.1-RC4</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/ranger-http-model/pom.xml
+++ b/ranger-http-model/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>ranger</artifactId>
         <groupId>io.appform.ranger</groupId>
-        <version>1.1-RC3</version>
+        <version>1.1-RC4</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/ranger-http/pom.xml
+++ b/ranger-http/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>ranger</artifactId>
         <groupId>io.appform.ranger</groupId>
-        <version>1.1-RC3</version>
+        <version>1.1-RC4</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/ranger-hub-server-bundle/pom.xml
+++ b/ranger-hub-server-bundle/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>ranger</artifactId>
         <groupId>io.appform.ranger</groupId>
-        <version>1.1-RC3</version>
+        <version>1.1-RC4</version>
     </parent>
     <build>
         <plugins>

--- a/ranger-server-bundle/pom.xml
+++ b/ranger-server-bundle/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>ranger</artifactId>
         <groupId>io.appform.ranger</groupId>
-        <version>1.1-RC3</version>
+        <version>1.1-RC4</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/ranger-server-common/pom.xml
+++ b/ranger-server-common/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>ranger</artifactId>
         <groupId>io.appform.ranger</groupId>
-        <version>1.1-RC3</version>
+        <version>1.1-RC4</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/ranger-server/pom.xml
+++ b/ranger-server/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.appform.ranger</groupId>
         <artifactId>ranger</artifactId>
-        <version>1.1-RC3</version>
+        <version>1.1-RC4</version>
     </parent>
 
     <artifactId>ranger-server</artifactId>

--- a/ranger-zk-client/pom.xml
+++ b/ranger-zk-client/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>ranger</artifactId>
         <groupId>io.appform.ranger</groupId>
-        <version>1.1-RC3</version>
+        <version>1.1-RC4</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/ranger-zookeeper/pom.xml
+++ b/ranger-zookeeper/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>ranger</artifactId>
         <groupId>io.appform.ranger</groupId>
-        <version>1.1-RC3</version>
+        <version>1.1-RC4</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
- Remove WaitStrategy in the Retryer used to check if ServiceRegistry is refreshed during ServiceRegistryUpdater startup
- Remove service-hub-refresh-timer ScheduledSignal because there's already one ScheduledSignal service-hub-updater used in ServiceFinderHub
