### PR TITLE
Fix to improve ServiceFinderHub startup time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [1.1-RC4]
+- Remove WaitStrategy in the Retryer used to check if ServiceRegistry is refreshed during ServiceRegistryUpdater startup
+
 ## [1.1-RC3]
 - Execute updateRegistry operation in async inside  ServiceFinderHub so that main thread reaches till waitTillHubIsReady instead of waiting for lock release and hubStartTimeoutMs is honoured as expected
 - Setting the read timeout and write timeout in OkHttpClient same as operation timeout given in HttpClientConfig

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <groupId>io.appform.ranger</groupId>
     <artifactId>ranger</artifactId>
     <packaging>pom</packaging>
-    <version>1.1-RC3</version>
+    <version>1.1-RC4</version>
     <name>Ranger</name>
     <url>https://github.com/appform-io/ranger</url>
     <description>Service Discovery for Java</description>

--- a/ranger-client/pom.xml
+++ b/ranger-client/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>ranger</artifactId>
         <groupId>io.appform.ranger</groupId>
-        <version>1.1-RC3</version>
+        <version>1.1-RC4</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/ranger-core/pom.xml
+++ b/ranger-core/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>ranger</artifactId>
         <groupId>io.appform.ranger</groupId>
-        <version>1.1-RC3</version>
+        <version>1.1-RC4</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/ranger-core/src/main/java/io/appform/ranger/core/finder/serviceregistry/ServiceRegistryUpdater.java
+++ b/ranger-core/src/main/java/io/appform/ranger/core/finder/serviceregistry/ServiceRegistryUpdater.java
@@ -75,7 +75,6 @@ public class ServiceRegistryUpdater<T, D extends Deserializer<T>> {
             RetryerBuilder.<Boolean>newBuilder()
                     .retryIfResult(r -> null == r || !r)
                     .retryIfException()
-                    .withWaitStrategy(WaitStrategies.fixedWait(1, TimeUnit.SECONDS))
                     .build()
                     .call(serviceRegistry::isRefreshed);
         }

--- a/ranger-discovery-bundle/pom.xml
+++ b/ranger-discovery-bundle/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>ranger</artifactId>
         <groupId>io.appform.ranger</groupId>
-        <version>1.1-RC3</version>
+        <version>1.1-RC4</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/ranger-drove-client/pom.xml
+++ b/ranger-drove-client/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>ranger</artifactId>
         <groupId>io.appform.ranger</groupId>
-        <version>1.1-RC3</version>
+        <version>1.1-RC4</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/ranger-drove/pom.xml
+++ b/ranger-drove/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>ranger</artifactId>
         <groupId>io.appform.ranger</groupId>
-        <version>1.1-RC3</version>
+        <version>1.1-RC4</version>
     </parent>
     <properties>
         <drove.version>1.30</drove.version>

--- a/ranger-http-client/pom.xml
+++ b/ranger-http-client/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>ranger</artifactId>
         <groupId>io.appform.ranger</groupId>
-        <version>1.1-RC3</version>
+        <version>1.1-RC4</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/ranger-http-model/pom.xml
+++ b/ranger-http-model/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>ranger</artifactId>
         <groupId>io.appform.ranger</groupId>
-        <version>1.1-RC3</version>
+        <version>1.1-RC4</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/ranger-http/pom.xml
+++ b/ranger-http/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>ranger</artifactId>
         <groupId>io.appform.ranger</groupId>
-        <version>1.1-RC3</version>
+        <version>1.1-RC4</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/ranger-hub-server-bundle/pom.xml
+++ b/ranger-hub-server-bundle/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>ranger</artifactId>
         <groupId>io.appform.ranger</groupId>
-        <version>1.1-RC3</version>
+        <version>1.1-RC4</version>
     </parent>
     <build>
         <plugins>

--- a/ranger-server-bundle/pom.xml
+++ b/ranger-server-bundle/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>ranger</artifactId>
         <groupId>io.appform.ranger</groupId>
-        <version>1.1-RC3</version>
+        <version>1.1-RC4</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/ranger-server-common/pom.xml
+++ b/ranger-server-common/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>ranger</artifactId>
         <groupId>io.appform.ranger</groupId>
-        <version>1.1-RC3</version>
+        <version>1.1-RC4</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/ranger-server/pom.xml
+++ b/ranger-server/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.appform.ranger</groupId>
         <artifactId>ranger</artifactId>
-        <version>1.1-RC3</version>
+        <version>1.1-RC4</version>
     </parent>
 
     <artifactId>ranger-server</artifactId>

--- a/ranger-zk-client/pom.xml
+++ b/ranger-zk-client/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>ranger</artifactId>
         <groupId>io.appform.ranger</groupId>
-        <version>1.1-RC3</version>
+        <version>1.1-RC4</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/ranger-zookeeper/pom.xml
+++ b/ranger-zookeeper/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>ranger</artifactId>
         <groupId>io.appform.ranger</groupId>
-        <version>1.1-RC3</version>
+        <version>1.1-RC4</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
- Remove WaitStrategy in the Retryer used to check if ServiceRegistry is refreshed during ServiceRegistryUpdater startup
