### PR TITLE
Server to Server Replication

### DIFF
--- a/ranger-client/src/main/java/io/appform/ranger/client/AbstractRangerHubClient.java
+++ b/ranger-client/src/main/java/io/appform/ranger/client/AbstractRangerHubClient.java
@@ -22,21 +22,14 @@ import io.appform.ranger.core.finderhub.ServiceDataSource;
 import io.appform.ranger.core.finderhub.ServiceFinderFactory;
 import io.appform.ranger.core.finderhub.ServiceFinderHub;
 import io.appform.ranger.core.model.*;
-
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.Set;
-import java.util.concurrent.CompletableFuture;
-import java.util.function.Predicate;
-import java.util.stream.Collectors;
-
 import io.appform.ranger.core.util.FinderUtils;
 import lombok.Getter;
 import lombok.experimental.SuperBuilder;
 import lombok.extern.slf4j.Slf4j;
+
+import java.util.*;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Predicate;
 
 @Slf4j
 @Getter
@@ -63,6 +56,7 @@ public abstract class AbstractRangerHubClient<T, R extends ServiceRegistry<T>, D
      */
     private long hubStartTimeoutMs;
     private Set<String> excludedServices;
+    private boolean replicationSource;
 
     @Override
     public void start() {

--- a/ranger-client/src/main/java/io/appform/ranger/client/RangerHubClient.java
+++ b/ranger-client/src/main/java/io/appform/ranger/client/RangerHubClient.java
@@ -58,4 +58,6 @@ public interface RangerHubClient<T, R extends ServiceRegistry<T>> {
             final Service service,
             final Predicate<T> criteria,
             final ShardSelector<T, R> shardSelector);
+
+    boolean isReplicationSource();
 }

--- a/ranger-core/src/main/java/io/appform/ranger/core/finderhub/ServiceFinderHub.java
+++ b/ranger-core/src/main/java/io/appform/ranger/core/finderhub/ServiceFinderHub.java
@@ -78,15 +78,16 @@ public class ServiceFinderHub<T, R extends ServiceRegistry<T>> {
     private final long hubStartTimeoutMs;
 
     private final Set<String> excludedServices;
+    @Getter
+    private final boolean replicationSource;
 
     private final ForkJoinPool refresherPool;
 
     public ServiceFinderHub(
             ServiceDataSource serviceDataSource,
-            ServiceFinderFactory<T, R> finderFactory
-                           ) {
+            ServiceFinderFactory<T, R> finderFactory) {
         this(serviceDataSource, finderFactory,
-                HubConstants.SERVICE_REFRESH_TIMEOUT_MS, HubConstants.HUB_START_TIMEOUT_MS, Set.of());
+             HubConstants.SERVICE_REFRESH_TIMEOUT_MS, HubConstants.HUB_START_TIMEOUT_MS, Set.of(), false);
     }
 
     public ServiceFinderHub(
@@ -94,11 +95,13 @@ public class ServiceFinderHub<T, R extends ServiceRegistry<T>> {
             ServiceFinderFactory<T, R> finderFactory,
             long serviceRefreshTimeoutMs,
             long hubStartTimeoutMs,
-            final Set<String> excludedServices) {
+            final Set<String> excludedServices,
+            boolean replicationSource) {
         this.serviceDataSource = serviceDataSource;
         this.finderFactory = finderFactory;
         this.serviceRefreshTimeoutMs = serviceRefreshTimeoutMs == 0 ? HubConstants.SERVICE_REFRESH_TIMEOUT_MS : serviceRefreshTimeoutMs;
         this.hubStartTimeoutMs = hubStartTimeoutMs == 0 ? HubConstants.HUB_START_TIMEOUT_MS : hubStartTimeoutMs;
+        this.replicationSource = replicationSource;
         this.refreshSignals.add(new ScheduledSignal<>("service-hub-updater",
                                                       () -> null,
                                                       Collections.emptyList(),

--- a/ranger-core/src/main/java/io/appform/ranger/core/finderhub/ServiceFinderHubBuilder.java
+++ b/ranger-core/src/main/java/io/appform/ranger/core/finderhub/ServiceFinderHubBuilder.java
@@ -20,11 +20,9 @@ import io.appform.ranger.core.model.HubConstants;
 import io.appform.ranger.core.model.ServiceRegistry;
 import io.appform.ranger.core.signals.ScheduledSignal;
 import io.appform.ranger.core.signals.Signal;
-
-import java.util.*;
-
 import lombok.val;
 
+import java.util.*;
 import java.util.function.Consumer;
 
 /**
@@ -40,6 +38,8 @@ public abstract class ServiceFinderHubBuilder<T, R extends ServiceRegistry<T>> {
     private final List<Signal<Void>> extraRefreshSignals = new ArrayList<>();
     private long serviceRefreshTimeoutMs = HubConstants.SERVICE_REFRESH_TIMEOUT_MS;
     private long hubStartTimeoutMs = HubConstants.HUB_START_TIMEOUT_MS;
+    private boolean replicationSource = false;
+
     private Set<String> excludedServices = new HashSet<>();
 
     public ServiceFinderHubBuilder<T, R> withServiceDataSource(ServiceDataSource serviceDataSource) {
@@ -87,13 +87,18 @@ public abstract class ServiceFinderHubBuilder<T, R extends ServiceRegistry<T>> {
         return this;
     }
 
+    public ServiceFinderHubBuilder<T, R> withReplicationSource(boolean replicationSource) {
+        this.replicationSource = replicationSource;
+        return this;
+    }
+
     public ServiceFinderHub<T, R> build() {
         preBuild();
         Preconditions.checkNotNull(serviceDataSource, "Provide a non-null service data source");
         Preconditions.checkNotNull(serviceFinderFactory, "Provide a non-null service finder factory");
 
         val hub = new ServiceFinderHub<>(serviceDataSource, serviceFinderFactory, serviceRefreshTimeoutMs,
-                hubStartTimeoutMs, excludedServices);
+                hubStartTimeoutMs, excludedServices, replicationSource);
         final ScheduledSignal<Void> refreshSignal = new ScheduledSignal<>("service-hub-refresh-timer",
                                                                           () -> null,
                                                                           Collections.emptyList(),

--- a/ranger-core/src/test/java/io/appform/ranger/core/finderhub/ServiceFinderHubTest.java
+++ b/ranger-core/src/test/java/io/appform/ranger/core/finderhub/ServiceFinderHubTest.java
@@ -27,15 +27,11 @@ import io.appform.ranger.core.healthcheck.HealthcheckStatus;
 import io.appform.ranger.core.model.*;
 import io.appform.ranger.core.units.TestNodeData;
 import io.appform.ranger.core.utils.RangerTestUtils;
-import java.util.Set;
 import lombok.val;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 
 class ServiceFinderHubTest {
 
@@ -93,8 +89,7 @@ class ServiceFinderHubTest {
                         .withServiceName(service.getServiceName())
                         .withDeserializer(new Deserializer<TestNodeData>() {})
                         .withSleepDuration(5)
-                        .build(), 1_000, 5_000, Set.of()
-        );
+                        .build(), 1_000, 5_000, Set.of(), false);
         Assertions.assertThrows(IllegalStateException.class, delayedHub::start);
         val serviceFinderHub = new ServiceFinderHub<>(new DynamicDataSource(Lists.newArrayList(new Service("NS", "SERVICE"))),
                 service ->  new TestServiceFinderBuilder()
@@ -102,8 +97,7 @@ class ServiceFinderHubTest {
                         .withServiceName(service.getServiceName())
                         .withDeserializer(new Deserializer<TestNodeData>() {})
                         .withSleepDuration(1)
-                        .build(), 5_000, 5_000, Set.of()
-        );
+                        .build(), 5_000, 5_000, Set.of(), false);
         serviceFinderHub.start();
         Assertions.assertTrue(serviceFinderHub.finder(new Service("NS", "SERVICE")).isPresent());
     }

--- a/ranger-discovery-bundle/perf/results/io.appform.ranger.discovery.bundle.id.IdGeneratorPerfTest.testGenerate.json
+++ b/ranger-discovery-bundle/perf/results/io.appform.ranger.discovery.bundle.id.IdGeneratorPerfTest.testGenerate.json
@@ -4,5 +4,5 @@
   "iterations" : 4,
   "threads" : 1,
   "forks" : 3,
-  "mean_ops" : 812476.3197574528
+  "mean_ops" : 780203.0578756403
 }

--- a/ranger-discovery-bundle/perf/results/io.appform.ranger.discovery.bundle.id.IdGeneratorPerfTest.testGenerateBase36.json
+++ b/ranger-discovery-bundle/perf/results/io.appform.ranger.discovery.bundle.id.IdGeneratorPerfTest.testGenerateBase36.json
@@ -4,5 +4,5 @@
   "iterations" : 4,
   "threads" : 1,
   "forks" : 3,
-  "mean_ops" : 592802.8071907263
+  "mean_ops" : 610879.2316480416
 }

--- a/ranger-drove-client/src/main/java/io/appform/ranger/client/drove/AbstractRangerDroveHubClient.java
+++ b/ranger-drove-client/src/main/java/io/appform/ranger/client/drove/AbstractRangerDroveHubClient.java
@@ -21,11 +21,11 @@ import io.appform.ranger.core.finderhub.ServiceDataSource;
 import io.appform.ranger.core.finderhub.ServiceFinderHub;
 import io.appform.ranger.core.model.ServiceNodeSelector;
 import io.appform.ranger.core.model.ServiceRegistry;
+import io.appform.ranger.drove.common.DroveCommunicator;
 import io.appform.ranger.drove.config.DroveUpstreamConfig;
 import io.appform.ranger.drove.serde.DroveResponseDataDeserializer;
 import io.appform.ranger.drove.servicefinderhub.DroveServiceDataSource;
 import io.appform.ranger.drove.servicefinderhub.DroveServiceFinderHubBuilder;
-import io.appform.ranger.drove.common.DroveCommunicator;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.experimental.SuperBuilder;
@@ -34,29 +34,31 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @Getter
 @SuperBuilder
-public abstract class AbstractRangerDroveHubClient<T, R extends ServiceRegistry<T>, D extends DroveResponseDataDeserializer<T>>
+public abstract class AbstractRangerDroveHubClient<T, R extends ServiceRegistry<T>,
+        D extends DroveResponseDataDeserializer<T>>
         extends AbstractRangerHubClient<T, R, D> {
 
-  private final DroveUpstreamConfig clientConfig;
-  private final DroveCommunicator droveCommunicator;
+    private final DroveUpstreamConfig clientConfig;
+    private final DroveCommunicator droveCommunicator;
 
-  @Builder.Default
-  private final ServiceNodeSelector<T> nodeSelector = new RandomServiceNodeSelector<>();
+    @Builder.Default
+    private final ServiceNodeSelector<T> nodeSelector = new RandomServiceNodeSelector<>();
 
-  @Override
-  protected ServiceDataSource getDefaultDataSource() {
-    return new DroveServiceDataSource<>(clientConfig, getMapper(), getNamespace(), droveCommunicator);
-  }
+    @Override
+    protected ServiceDataSource getDefaultDataSource() {
+        return new DroveServiceDataSource<>(clientConfig, getMapper(), getNamespace(), droveCommunicator);
+    }
 
-  @Override
-  protected ServiceFinderHub<T, R> buildHub() {
-    return new DroveServiceFinderHubBuilder<T, R>()
-        .withServiceDataSource(getServiceDataSource())
-        .withServiceFinderFactory(getFinderFactory())
-        .withRefreshFrequencyMs(getNodeRefreshTimeMs())
-        .withHubStartTimeout(getHubStartTimeoutMs())
-        .withServiceRefreshTimeout(getServiceRefreshTimeoutMs())
-        .withExcludedServices(getExcludedServices())
-        .build();
-  }
+    @Override
+    protected ServiceFinderHub<T, R> buildHub() {
+        return new DroveServiceFinderHubBuilder<T, R>()
+                .withServiceDataSource(getServiceDataSource())
+                .withServiceFinderFactory(getFinderFactory())
+                .withRefreshFrequencyMs(getNodeRefreshTimeMs())
+                .withHubStartTimeout(getHubStartTimeoutMs())
+                .withServiceRefreshTimeout(getServiceRefreshTimeoutMs())
+                .withExcludedServices(getExcludedServices())
+                .withReplicationSource(isReplicationSource())
+                .build();
+    }
 }

--- a/ranger-http-client/src/main/java/io/appform/ranger/client/http/AbstractRangerHttpHubClient.java
+++ b/ranger-http-client/src/main/java/io/appform/ranger/client/http/AbstractRangerHttpHubClient.java
@@ -66,6 +66,7 @@ public abstract class AbstractRangerHttpHubClient<T, R extends ServiceRegistry<T
                 .withHubStartTimeout(getHubStartTimeoutMs())
                 .withServiceRefreshTimeout(getServiceRefreshTimeoutMs())
                 .withExcludedServices(getExcludedServices())
+                .withReplicationSource(isReplicationSource())
                 .build();
     }
 }

--- a/ranger-http-client/src/test/java/io/appform/ranger/client/http/BaseRangerHttpClientTest.java
+++ b/ranger-http-client/src/test/java/io/appform/ranger/client/http/BaseRangerHttpClientTest.java
@@ -61,7 +61,7 @@ public abstract class BaseRangerHttpClientTest {
                 ServiceNodesResponse.<TestNodeData>builder()
                         .data(Lists.newArrayList(node))
                         .build());
-        wireMockExtension.stubFor(get(urlEqualTo("/ranger/nodes/v1/test-n/test-s"))
+        wireMockExtension.stubFor(get(urlPathEqualTo("/ranger/nodes/v1/test-n/test-s"))
                 .willReturn(aResponse()
                         .withBody(payload)
                         .withStatus(200)));
@@ -72,7 +72,7 @@ public abstract class BaseRangerHttpClientTest {
                 ))
                 .build();
         val response = objectMapper.writeValueAsBytes(responseObj);
-        wireMockExtension.stubFor(get(urlEqualTo("/ranger/services/v1"))
+        wireMockExtension.stubFor(get(urlPathEqualTo("/ranger/services/v1"))
                 .willReturn(aResponse()
                         .withBody(response)
                         .withStatus(200)));

--- a/ranger-http/pom.xml
+++ b/ranger-http/pom.xml
@@ -55,5 +55,11 @@
             <version>${project.version}</version>
             <type>test-jar</type>
         </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>${logback.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/ranger-http/src/main/java/io/appform/ranger/http/config/HttpClientConfig.java
+++ b/ranger-http/src/main/java/io/appform/ranger/http/config/HttpClientConfig.java
@@ -34,4 +34,5 @@ public class HttpClientConfig {
     long connectionTimeoutMs;
     long operationTimeoutMs;
     long refreshIntervalMillis;
+    boolean skipReplicatedData;
 }

--- a/ranger-http/src/main/java/io/appform/ranger/http/servicefinder/HttpApiCommunicator.java
+++ b/ranger-http/src/main/java/io/appform/ranger/http/servicefinder/HttpApiCommunicator.java
@@ -73,6 +73,7 @@ public class HttpApiCommunicator<T> implements HttpCommunicator<T> {
                     .host(config.getHost())
                     .port(config.getPort() == 0 ? defaultPort() : config.getPort())
                     .encodedPath("/ranger/services/v1")
+                    .addQueryParameter("skipReplicationSources", Objects.toString(config.isSkipReplicatedData()))
                     .build();
             val request = new Request.Builder()
                     .url(httpUrl)
@@ -109,6 +110,7 @@ public class HttpApiCommunicator<T> implements HttpCommunicator<T> {
                     .host(config.getHost())
                     .port(config.getPort() == 0 ? defaultPort() : config.getPort())
                     .encodedPath(url)
+                    .addQueryParameter("skipReplicationSources", Objects.toString(config.isSkipReplicatedData()))
                     .build();
             val request = new Request.Builder()
                     .url(httpUrl)

--- a/ranger-http/src/test/java/io/appform/ranger/http/servicefinder/HttpShardedServiceFinderBuilderTest.java
+++ b/ranger-http/src/test/java/io/appform/ranger/http/servicefinder/HttpShardedServiceFinderBuilderTest.java
@@ -62,7 +62,7 @@ class HttpShardedServiceFinderBuilderTest {
                 ServiceNodesResponse.<NodeData>builder()
                         .data(Collections.singletonList(node))
                         .build());
-        stubFor(get(urlEqualTo("/ranger/nodes/v1/testns/test"))
+        stubFor(get(urlPathEqualTo("/ranger/nodes/v1/testns/test"))
                                .willReturn(aResponse()
                                                    .withBody(payload)
                                                    .withStatus(200)));

--- a/ranger-http/src/test/java/io/appform/ranger/http/servicefinderhub/HttpServiceDataSourceTest.java
+++ b/ranger-http/src/test/java/io/appform/ranger/http/servicefinderhub/HttpServiceDataSourceTest.java
@@ -35,34 +35,68 @@ import static com.github.tomakehurst.wiremock.client.WireMock.*;
 class HttpServiceDataSourceTest {
 
     private static final ObjectMapper MAPPER = new ObjectMapper();
+
     @Test
     void testServiceDataSource(WireMockRuntimeInfo wireMockRuntimeInfo) throws IOException {
-        val responseObj = ServiceDataSourceResponse.builder()
+        val responseObjReplicated = ServiceDataSourceResponse.builder()
                 .data(Sets.newHashSet(
                         RangerTestUtils.getService("test-n", "test-s"),
                         RangerTestUtils.getService("test-n", "test-s1"),
                         RangerTestUtils.getService("test-n", "test-s2")
                 ))
                 .build();
-        val response = MAPPER.writeValueAsBytes(responseObj);
-        stubFor(get(urlPathEqualTo("/ranger/services/v1"))
+        stubFor(get(urlEqualTo("/ranger/services/v1?skipReplicationSources=false"))
                 .willReturn(aResponse()
-                        .withBody(response)
+                        .withBody(MAPPER.writeValueAsBytes(responseObjReplicated))
                         .withStatus(200)));
-        val clientConfig = HttpClientConfig.builder()
-                .host("127.0.0.1")
-                .port(wireMockRuntimeInfo.getHttpPort())
-                .connectionTimeoutMs(30_000)
-                .operationTimeoutMs(30_000)
+        val responseObjReplicationSkipped = ServiceDataSourceResponse.builder()
+                .data(Sets.newHashSet(
+                        RangerTestUtils.getService("test-n", "test-s"),
+                        RangerTestUtils.getService("test-n", "test-s1")))
                 .build();
-        val httpServiceDataSource = new HttpServiceDataSource<>(clientConfig, RangerHttpUtils.httpClient(clientConfig, MAPPER));
-        val services = httpServiceDataSource.services();
-        Assertions.assertNotNull(services);
-        Assertions.assertFalse(services.isEmpty());
-        Assertions.assertEquals(3, services.size());
-        Assertions.assertFalse(services.stream().noneMatch(each -> each.getServiceName().equalsIgnoreCase("test-s")));
-        Assertions.assertFalse(services.stream().noneMatch(each -> each.getServiceName().equalsIgnoreCase("test-s1")));
-        Assertions.assertFalse(services.stream().noneMatch(each -> each.getServiceName().equalsIgnoreCase("test-s2")));
+        stubFor(get(urlEqualTo("/ranger/services/v1?skipReplicationSources=true"))
+                .willReturn(aResponse()
+                        .withBody(MAPPER.writeValueAsBytes(responseObjReplicationSkipped))
+                        .withStatus(200)));
+        {
+            val clientConfig = HttpClientConfig.builder()
+                    .host("127.0.0.1")
+                    .port(wireMockRuntimeInfo.getHttpPort())
+                    .connectionTimeoutMs(30_000)
+                    .operationTimeoutMs(30_000)
+                    .build();
+            val httpServiceDataSource = new HttpServiceDataSource<>(clientConfig,
+                                                                    RangerHttpUtils.httpClient(clientConfig, MAPPER));
+            val services = httpServiceDataSource.services();
+            Assertions.assertNotNull(services);
+            Assertions.assertFalse(services.isEmpty());
+            Assertions.assertEquals(3, services.size());
+            Assertions.assertFalse(services.stream()
+                                           .noneMatch(each -> each.getServiceName().equalsIgnoreCase("test-s")));
+            Assertions.assertFalse(services.stream()
+                                           .noneMatch(each -> each.getServiceName().equalsIgnoreCase("test-s1")));
+            Assertions.assertFalse(services.stream()
+                                           .noneMatch(each -> each.getServiceName().equalsIgnoreCase("test-s2")));
+        }
+        { //Here we set skip replication data to false. so query param is set
+            val clientConfig = HttpClientConfig.builder()
+                    .host("127.0.0.1")
+                    .port(wireMockRuntimeInfo.getHttpPort())
+                    .connectionTimeoutMs(30_000)
+                    .operationTimeoutMs(30_000)
+                    .skipReplicatedData(true)
+                    .build();
+            val httpServiceDataSource = new HttpServiceDataSource<>(clientConfig,
+                                                                    RangerHttpUtils.httpClient(clientConfig, MAPPER));
+            val services = httpServiceDataSource.services();
+            Assertions.assertNotNull(services);
+            Assertions.assertFalse(services.isEmpty());
+            Assertions.assertEquals(2, services.size());
+            Assertions.assertFalse(services.stream()
+                                           .noneMatch(each -> each.getServiceName().equalsIgnoreCase("test-s")));
+            Assertions.assertFalse(services.stream()
+                                           .noneMatch(each -> each.getServiceName().equalsIgnoreCase("test-s1")));
+        }
     }
 
 }

--- a/ranger-http/src/test/java/io/appform/ranger/http/servicefinderhub/HttpServiceDataSourceTest.java
+++ b/ranger-http/src/test/java/io/appform/ranger/http/servicefinderhub/HttpServiceDataSourceTest.java
@@ -45,7 +45,7 @@ class HttpServiceDataSourceTest {
                 ))
                 .build();
         val response = MAPPER.writeValueAsBytes(responseObj);
-        stubFor(get(urlEqualTo("/ranger/services/v1"))
+        stubFor(get(urlPathEqualTo("/ranger/services/v1"))
                 .willReturn(aResponse()
                         .withBody(response)
                         .withStatus(200)));

--- a/ranger-http/src/test/java/io/appform/ranger/http/serviceprovider/HttpShardedServiceProviderBuilderTest.java
+++ b/ranger-http/src/test/java/io/appform/ranger/http/serviceprovider/HttpShardedServiceProviderBuilderTest.java
@@ -61,7 +61,7 @@ class HttpShardedServiceProviderBuilderTest {
                         )
                         .build());
         byte[] requestBytes = MAPPER.writeValueAsBytes(testNode);
-        stubFor(post(urlEqualTo("/ranger/nodes/v1/add/testns/test"))
+        stubFor(post(urlPathEqualTo("/ranger/nodes/v1/add/testns/test"))
                 .withRequestBody(binaryEqualTo(requestBytes))
                 .willReturn(aResponse()
                         .withBody(response)

--- a/ranger-hub-server-bundle/src/main/java/io/appform/ranger/hub/server/bundle/RangerHubServerBundle.java
+++ b/ranger-hub-server-bundle/src/main/java/io/appform/ranger/hub/server/bundle/RangerHubServerBundle.java
@@ -109,6 +109,7 @@ public abstract class RangerHubServerBundle<U extends Configuration>
                     .hubStartTimeoutMs(zkConfiguration.getHubStartTimeoutMs())
                     .nodeRefreshTimeMs(zkConfiguration.getNodeRefreshTimeMs())
                     .excludedServices(excludedServices)
+                    .replicationSource(zkConfiguration.isReplicationSource())
                     .deserializer(data -> {
                         try {
                             return getMapper().readValue(data, new TypeReference<ServiceNode<ShardInfo>>() {
@@ -133,6 +134,7 @@ public abstract class RangerHubServerBundle<U extends Configuration>
                     .hubStartTimeoutMs(httpConfiguration.getHubStartTimeoutMs())
                     .nodeRefreshTimeMs(httpConfiguration.getNodeRefreshTimeMs())
                     .excludedServices(excludedServices)
+                    .replicationSource(httpConfiguration.isReplicationSource())
                     .deserializer(data -> {
                         try {
                             return getMapper().readValue(data, new TypeReference<>() {});
@@ -161,6 +163,7 @@ public abstract class RangerHubServerBundle<U extends Configuration>
                     .hubStartTimeoutMs(droveUpstreamConfiguration.getHubStartTimeoutMs())
                     .nodeRefreshTimeMs(droveUpstreamConfiguration.getNodeRefreshTimeMs())
                     .excludedServices(excludedServices)
+                    .replicationSource(droveUpstreamConfiguration.isReplicationSource())
                     .deserializer(new DroveResponseDataDeserializer<>() {
                         @Override
                         protected ShardInfo translate(ExposedAppInfo appInfo, ExposedAppInfo.ExposedHost host) {

--- a/ranger-hub-server-bundle/src/main/java/io/appform/ranger/hub/server/bundle/configuration/RangerUpstreamConfiguration.java
+++ b/ranger-hub-server-bundle/src/main/java/io/appform/ranger/hub/server/bundle/configuration/RangerUpstreamConfiguration.java
@@ -47,6 +47,8 @@ public abstract class RangerUpstreamConfiguration {
   @Min(HubConstants.MINIMUM_HUB_START_TIMEOUT_MS)
   private int hubStartTimeoutMs = HubConstants.HUB_START_TIMEOUT_MS;
 
+  private boolean replicationSource;
+
   protected RangerUpstreamConfiguration(BackendType type) {
     this.type = type;
   }

--- a/ranger-hub-server-bundle/src/test/java/io/appform/ranger/hub/server/bundle/RangerHubServerBundleTest.java
+++ b/ranger-hub-server-bundle/src/test/java/io/appform/ranger/hub/server/bundle/RangerHubServerBundleTest.java
@@ -106,12 +106,12 @@ class RangerHubServerBundleTest {
                                 .serviceName("service-" + i)
                                 .build())
                                 .collect(Collectors.toUnmodifiableSet());
-        stubFor(get("/ranger/services/v1")
+        stubFor(get(urlPathEqualTo("/ranger/services/v1"))
                         .willReturn(okJson(environment.getObjectMapper()
                                                .writeValueAsString(ServiceDataSourceResponse.builder()
                                                                                 .data(services)
                                                                .build()))));
-        stubFor(any(urlMatching("/ranger/nodes/v1/test/service-[0-9]+"))
+        stubFor(any(urlPathMatching("/ranger/nodes/v1/test/service-[0-9]+"))
                         .willReturn(okJson(mapper.writeValueAsString(
                                 ServiceNodesResponse.builder()
                                         .data(IntStream.rangeClosed(1, 5)

--- a/ranger-zk-client/src/main/java/io/appform/ranger/client/zk/AbstractRangerZKHubClient.java
+++ b/ranger-zk-client/src/main/java/io/appform/ranger/client/zk/AbstractRangerZKHubClient.java
@@ -36,10 +36,11 @@ public abstract class AbstractRangerZKHubClient<T, R extends ServiceRegistry<T>,
     private final boolean disablePushUpdaters;
     private final String connectionString;
     private final CuratorFramework curatorFramework;
+    private boolean replicationSource;
 
     @Override
     protected ServiceFinderHub<T, R> buildHub() {
-       return new ZkServiceFinderHubBuilder<T, R>()
+        return new ZkServiceFinderHubBuilder<T, R>()
                 .withCuratorFramework(curatorFramework)
                 .withConnectionString(connectionString)
                 .withNamespace(getNamespace())
@@ -49,6 +50,7 @@ public abstract class AbstractRangerZKHubClient<T, R extends ServiceRegistry<T>,
                 .withHubStartTimeout(getHubStartTimeoutMs())
                 .withServiceRefreshTimeout(getServiceRefreshTimeoutMs())
                 .withExcludedServices(getExcludedServices())
+                .withReplicationSource(isReplicationSource())
                 .build();
     }
 


### PR DESCRIPTION
**Problem**
Right now, if two ranger servers point to each other as upstream, they each receive _all_ nodes from each other leading to a circular infinite loop.

**Solution**
We identify HTTP sources from which we are replicating and provide a flag in the `/nodes` and `/services` APIs to skip send out data from hubs identified as replication sources.

**Effect**
- A client calling the apis without a flag (basically all normal ranger clients) will get data from everywhere as it does currently.
- If `HttpClientConfig` for a HTTP based client has the `skipReplicatedData` then the query parameter is set so that the upstream sends it only the data it has.
- In the upstreamConfiguration of the ranger server configuration, a source can be marked as a `replicationSource` for the query parameter based filter to appear.