### PR TITLE
Avoid duplicate ID in case of backwards time drift

### DIFF
--- a/ranger-discovery-bundle/src/main/java/io/appform/ranger/discovery/bundle/id/IdGenerator.java
+++ b/ranger-discovery-bundle/src/main/java/io/appform/ranger/discovery/bundle/id/IdGenerator.java
@@ -306,12 +306,12 @@ public class IdGenerator {
 
     private static IdInfo random(CollisionChecker collisionChecker) {
         int randomGen;
-        long time;
+        long curTimeMs;
         do {
-            time = System.currentTimeMillis();
+            curTimeMs = System.currentTimeMillis();
             randomGen = SECURE_RANDOM.nextInt(Constants.MAX_ID_PER_MS);
-        } while (!collisionChecker.check(time, randomGen));
-        return new IdInfo(randomGen, time);
+        } while (!collisionChecker.check(curTimeMs, randomGen));
+        return new IdInfo(randomGen, curTimeMs);
     }
 
     private static IdValidationState validateId(List<IdValidationConstraint> inConstraints, Id id, boolean skipGlobal) {

--- a/ranger-discovery-bundle/src/test/java/io/appform/ranger/discovery/bundle/id/CollisionCheckerTest.java
+++ b/ranger-discovery-bundle/src/test/java/io/appform/ranger/discovery/bundle/id/CollisionCheckerTest.java
@@ -37,4 +37,13 @@ class CollisionCheckerTest {
             Assertions.assertFalse(collisionChecker.check(101, i));
         });
     }
+
+    @Test
+    void testCheckGoingBackInTime() {
+        CollisionChecker collisionChecker = new CollisionChecker();
+        Assertions.assertTrue(collisionChecker.check(100, 1));
+        Assertions.assertFalse(collisionChecker.check(90, 1));
+        Assertions.assertFalse(collisionChecker.check(100, 1));
+        Assertions.assertTrue(collisionChecker.check(101, 1));
+    }
 }


### PR DESCRIPTION
`System.currentTimeInMs()` is not a monotonically increasing counter. In case of backwards time drift due to NTP sync, it can go back which can result in duplicate ID's being generated as the `CollisionChecker` assumes that the time is only going forward.

This PR handles this edge case by directly rejecting the requests in case of current time < last processed timestamp.