### PR TITLE
Title: Introduce Weighted Node Selection for Gradual Traffic Ramp-Up

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <groupId>io.appform.ranger</groupId>
     <artifactId>ranger</artifactId>
     <packaging>pom</packaging>
-    <version>1.1-RC5</version>
+    <version>1.2-RC5</version>
     <name>Ranger</name>
     <url>https://github.com/appform-io/ranger</url>
     <description>Service Discovery for Java</description>

--- a/ranger-client/pom.xml
+++ b/ranger-client/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>ranger</artifactId>
         <groupId>io.appform.ranger</groupId>
-        <version>1.1-RC5</version>
+        <version>1.2-RC5</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/ranger-core/pom.xml
+++ b/ranger-core/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>ranger</artifactId>
         <groupId>io.appform.ranger</groupId>
-        <version>1.1-RC5</version>
+        <version>1.2-RC5</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/ranger-core/src/main/java/io/appform/ranger/core/finder/BaseServiceFinderBuilder.java
+++ b/ranger-core/src/main/java/io/appform/ranger/core/finder/BaseServiceFinderBuilder.java
@@ -18,10 +18,15 @@ package io.appform.ranger.core.finder;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
-import io.appform.ranger.core.finder.nodeselector.RandomServiceNodeSelector;
+import io.appform.ranger.core.finder.nodeselector.WeightedRandomServiceNodeSelector;
 import io.appform.ranger.core.finder.serviceregistry.ServiceRegistryUpdater;
 import io.appform.ranger.core.finder.serviceregistry.signal.ScheduledRegistryUpdateSignal;
-import io.appform.ranger.core.model.*;
+import io.appform.ranger.core.model.Deserializer;
+import io.appform.ranger.core.model.NodeDataSource;
+import io.appform.ranger.core.model.Service;
+import io.appform.ranger.core.model.ServiceNodeSelector;
+import io.appform.ranger.core.model.ServiceRegistry;
+import io.appform.ranger.core.model.ShardSelector;
 import io.appform.ranger.core.signals.Signal;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
@@ -48,7 +53,7 @@ public abstract class BaseServiceFinderBuilder
     protected boolean disablePushUpdaters;
     protected D deserializer;
     protected ShardSelector<T, R> shardSelector;
-    protected ServiceNodeSelector<T> nodeSelector = new RandomServiceNodeSelector<>();
+    protected ServiceNodeSelector<T> nodeSelector = new WeightedRandomServiceNodeSelector<>();
     protected final List<Signal<T>> additionalRefreshSignals = new ArrayList<>();
     protected final List<Consumer<Void>> startSignalHandlers = Lists.newArrayList();
     protected final List<Consumer<Void>> stopSignalHandlers = Lists.newArrayList();

--- a/ranger-core/src/main/java/io/appform/ranger/core/finder/nodeselector/WeightedRandomServiceNodeSelector.java
+++ b/ranger-core/src/main/java/io/appform/ranger/core/finder/nodeselector/WeightedRandomServiceNodeSelector.java
@@ -1,0 +1,36 @@
+package io.appform.ranger.core.finder.nodeselector;
+
+import io.appform.ranger.core.model.ServiceNode;
+import io.appform.ranger.core.model.ServiceNodeSelector;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+
+public class WeightedRandomServiceNodeSelector<T> implements ServiceNodeSelector<T> {
+
+    @Override
+    public ServiceNode<T> select(List<ServiceNode<T>> serviceNodes) {
+        if (serviceNodes == null || serviceNodes.isEmpty()) {
+            throw new IllegalArgumentException("Service nodes list cannot be empty");
+        }
+
+        double totalWeight = 0.0;
+        double[] cumulativeWeights = new double[serviceNodes.size()];
+
+        for (int i = 0; i < serviceNodes.size(); i++) {
+            totalWeight += serviceNodes.get(i).getWeight();
+            cumulativeWeights[i] = totalWeight;
+        }
+
+        double randomValue = ThreadLocalRandom.current().nextDouble(totalWeight);
+
+
+        int index = Arrays.binarySearch(cumulativeWeights, randomValue);
+        if (index < 0) {
+            index = -index - 1;
+        }
+
+        return serviceNodes.get(index);
+    }
+}

--- a/ranger-core/src/main/java/io/appform/ranger/core/model/ServiceNode.java
+++ b/ranger-core/src/main/java/io/appform/ranger/core/model/ServiceNode.java
@@ -28,6 +28,8 @@ import lombok.NoArgsConstructor;
 public class ServiceNode<T> {
     private String host;
     private int port;
+    @Builder.Default
+    private double weight = 1.0;
     private T nodeData;
     @Builder.Default
     private HealthcheckStatus healthcheckStatus = HealthcheckStatus.healthy;
@@ -36,6 +38,18 @@ public class ServiceNode<T> {
     //Can be any scheme that you intend to init.
     @Builder.Default
     private String portScheme = PortSchemes.HTTP;
+
+    public ServiceNode(final String host, final int port, final T nodeData, final HealthcheckStatus healthcheckStatus,
+                       final long lastUpdatedTimeStamp,
+                       final String portScheme) {
+        this.host = host;
+        this.port = port;
+        this.weight = 1;
+        this.nodeData = nodeData;
+        this.healthcheckStatus = healthcheckStatus;
+        this.lastUpdatedTimeStamp = lastUpdatedTimeStamp;
+        this.portScheme = portScheme;
+    }
 
     public String representation() {
         return String.format("%s:%d", host, port);

--- a/ranger-core/src/test/java/io/appform/ranger/core/finderhub/ServiceFinderHubTest.java
+++ b/ranger-core/src/test/java/io/appform/ranger/core/finderhub/ServiceFinderHubTest.java
@@ -186,7 +186,8 @@ private static class TestServiceFinderHubBuilder extends ServiceFinderHubBuilder
             @Override
             public Optional<List<ServiceNode<TestNodeData>>> refresh(Deserializer<TestNodeData> deserializer) {
                 val list = new ArrayList<ServiceNode<TestNodeData>>();
-                list.add(new ServiceNode<>("HOST", 0, TestNodeData.builder().shardId(1).build(), HealthcheckStatus.healthy, Long.MAX_VALUE, "HTTP"));
+                list.add(new ServiceNode<>("HOST", 0, 1f, TestNodeData.builder().shardId(1).build(),
+                                           HealthcheckStatus.healthy, Long.MAX_VALUE, "HTTP"));
                 return Optional.of(list);
             }
 

--- a/ranger-discovery-bundle/pom.xml
+++ b/ranger-discovery-bundle/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>ranger</artifactId>
         <groupId>io.appform.ranger</groupId>
-        <version>1.1-RC5</version>
+        <version>1.2-RC5</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/ranger-drove-client/pom.xml
+++ b/ranger-drove-client/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>ranger</artifactId>
         <groupId>io.appform.ranger</groupId>
-        <version>1.1-RC5</version>
+        <version>1.2-RC5</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/ranger-drove-client/src/main/java/io/appform/ranger/client/drove/AbstractRangerDroveHubClient.java
+++ b/ranger-drove-client/src/main/java/io/appform/ranger/client/drove/AbstractRangerDroveHubClient.java
@@ -16,7 +16,7 @@
 package io.appform.ranger.client.drove;
 
 import io.appform.ranger.client.AbstractRangerHubClient;
-import io.appform.ranger.core.finder.nodeselector.RandomServiceNodeSelector;
+import io.appform.ranger.core.finder.nodeselector.WeightedRandomServiceNodeSelector;
 import io.appform.ranger.core.finderhub.ServiceDataSource;
 import io.appform.ranger.core.finderhub.ServiceFinderHub;
 import io.appform.ranger.core.model.ServiceNodeSelector;
@@ -42,7 +42,7 @@ public abstract class AbstractRangerDroveHubClient<T, R extends ServiceRegistry<
     private final DroveCommunicator droveCommunicator;
 
     @Builder.Default
-    private final ServiceNodeSelector<T> nodeSelector = new RandomServiceNodeSelector<>();
+    private final ServiceNodeSelector<T> nodeSelector = new WeightedRandomServiceNodeSelector<>();
 
     @Override
     protected ServiceDataSource getDefaultDataSource() {

--- a/ranger-drove/pom.xml
+++ b/ranger-drove/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>ranger</artifactId>
         <groupId>io.appform.ranger</groupId>
-        <version>1.1-RC5</version>
+        <version>1.2-RC5</version>
     </parent>
     <properties>
         <drove.version>1.30</drove.version>

--- a/ranger-drove/src/main/java/io/appform/ranger/drove/serde/DroveResponseDataDeserializer.java
+++ b/ranger-drove/src/main/java/io/appform/ranger/drove/serde/DroveResponseDataDeserializer.java
@@ -22,7 +22,9 @@ import io.appform.ranger.core.model.ServiceNode;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -44,6 +46,7 @@ public abstract class DroveResponseDataDeserializer<T> implements Deserializer<T
                                              }
                                              return new ServiceNode<>(endpoint.getHost(),
                                                                       endpoint.getPort(),
+                                                                      1,
                                                                       info,
                                                                       HealthcheckStatus.healthy,
                                                                       currTime,

--- a/ranger-http-client/pom.xml
+++ b/ranger-http-client/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>ranger</artifactId>
         <groupId>io.appform.ranger</groupId>
-        <version>1.1-RC5</version>
+        <version>1.2-RC5</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/ranger-http-client/src/main/java/io/appform/ranger/client/http/AbstractRangerHttpHubClient.java
+++ b/ranger-http-client/src/main/java/io/appform/ranger/client/http/AbstractRangerHttpHubClient.java
@@ -16,7 +16,7 @@
 package io.appform.ranger.client.http;
 
 import io.appform.ranger.client.AbstractRangerHubClient;
-import io.appform.ranger.core.finder.nodeselector.RandomServiceNodeSelector;
+import io.appform.ranger.core.finder.nodeselector.WeightedRandomServiceNodeSelector;
 import io.appform.ranger.core.finderhub.ServiceDataSource;
 import io.appform.ranger.core.finderhub.ServiceFinderHub;
 import io.appform.ranger.core.model.ServiceNodeSelector;
@@ -46,7 +46,7 @@ public abstract class AbstractRangerHttpHubClient<T, R extends ServiceRegistry<T
     private final HttpCommunicator<T> httpClient;
 
     @Builder.Default
-    private final ServiceNodeSelector<T> nodeSelector = new RandomServiceNodeSelector<>();
+    private final ServiceNodeSelector<T> nodeSelector = new WeightedRandomServiceNodeSelector<>();
 
     @Override
     protected ServiceDataSource getDefaultDataSource() {

--- a/ranger-http-model/pom.xml
+++ b/ranger-http-model/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>ranger</artifactId>
         <groupId>io.appform.ranger</groupId>
-        <version>1.1-RC5</version>
+        <version>1.2-RC5</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/ranger-http/pom.xml
+++ b/ranger-http/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>ranger</artifactId>
         <groupId>io.appform.ranger</groupId>
-        <version>1.1-RC5</version>
+        <version>1.2-RC5</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/ranger-hub-server-bundle/pom.xml
+++ b/ranger-hub-server-bundle/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>ranger</artifactId>
         <groupId>io.appform.ranger</groupId>
-        <version>1.1-RC5</version>
+        <version>1.2-RC5</version>
     </parent>
     <build>
         <plugins>

--- a/ranger-server-bundle/pom.xml
+++ b/ranger-server-bundle/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>ranger</artifactId>
         <groupId>io.appform.ranger</groupId>
-        <version>1.1-RC5</version>
+        <version>1.2-RC5</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/ranger-server-common/pom.xml
+++ b/ranger-server-common/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>ranger</artifactId>
         <groupId>io.appform.ranger</groupId>
-        <version>1.1-RC5</version>
+        <version>1.2-RC5</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/ranger-server/pom.xml
+++ b/ranger-server/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.appform.ranger</groupId>
         <artifactId>ranger</artifactId>
-        <version>1.1-RC5</version>
+        <version>1.2-RC5</version>
     </parent>
 
     <artifactId>ranger-server</artifactId>

--- a/ranger-zk-client/pom.xml
+++ b/ranger-zk-client/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>ranger</artifactId>
         <groupId>io.appform.ranger</groupId>
-        <version>1.1-RC5</version>
+        <version>1.2-RC5</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/ranger-zk-client/src/main/java/io/appform/ranger/client/zk/ShardedRangerZKHubClient.java
+++ b/ranger-zk-client/src/main/java/io/appform/ranger/client/zk/ShardedRangerZKHubClient.java
@@ -15,7 +15,7 @@
  */
 package io.appform.ranger.client.zk;
 
-import io.appform.ranger.core.finder.nodeselector.RandomServiceNodeSelector;
+import io.appform.ranger.core.finder.nodeselector.WeightedRandomServiceNodeSelector;
 import io.appform.ranger.core.finder.serviceregistry.MapBasedServiceRegistry;
 import io.appform.ranger.core.finder.shardselector.MatchingShardSelector;
 import io.appform.ranger.core.finderhub.ServiceFinderFactory;
@@ -36,7 +36,7 @@ public class ShardedRangerZKHubClient<T>
     private final ShardSelector<T, MapBasedServiceRegistry<T>> shardSelector = new MatchingShardSelector<>();
 
     @Builder.Default
-    private final ServiceNodeSelector<T> nodeSelector = new RandomServiceNodeSelector<>();
+    private final ServiceNodeSelector<T> nodeSelector = new WeightedRandomServiceNodeSelector<>();
 
     @Override
     protected ServiceFinderFactory<T, MapBasedServiceRegistry<T>> getFinderFactory() {

--- a/ranger-zk-client/src/main/java/io/appform/ranger/client/zk/UnshardedRangerZKHubClient.java
+++ b/ranger-zk-client/src/main/java/io/appform/ranger/client/zk/UnshardedRangerZKHubClient.java
@@ -15,7 +15,7 @@
  */
 package io.appform.ranger.client.zk;
 
-import io.appform.ranger.core.finder.nodeselector.RandomServiceNodeSelector;
+import io.appform.ranger.core.finder.nodeselector.WeightedRandomServiceNodeSelector;
 import io.appform.ranger.core.finder.serviceregistry.ListBasedServiceRegistry;
 import io.appform.ranger.core.finder.shardselector.ListShardSelector;
 import io.appform.ranger.core.finderhub.ServiceFinderFactory;
@@ -36,7 +36,7 @@ public class UnshardedRangerZKHubClient<T>
     private final ShardSelector<T, ListBasedServiceRegistry<T>> shardSelector = new ListShardSelector<>();
 
     @Builder.Default
-    private final ServiceNodeSelector<T> nodeSelector = new RandomServiceNodeSelector<>();
+    private final ServiceNodeSelector<T> nodeSelector = new WeightedRandomServiceNodeSelector<>();
 
     @Override
     protected ServiceFinderFactory<T, ListBasedServiceRegistry<T>> getFinderFactory() {

--- a/ranger-zookeeper/pom.xml
+++ b/ranger-zookeeper/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>ranger</artifactId>
         <groupId>io.appform.ranger</groupId>
-        <version>1.1-RC5</version>
+        <version>1.2-RC5</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION

Description:
This MR replaces the existing random node selection strategy with a weighted selection strategy to ensure a smoother ramp-up for new service instances.

Key Changes:
Introduced a weight parameter in ServiceNode, which starts low and gradually increases based on the uptime of the service.

Implemented asigmoid-based weight function, ensuring a slow initial ramp-up that eventually converges to 1.

Replaced the random selection strategy with a probabilistic weighted selection, where instances with higher uptime (and weight) have a higher chance of being picked.

Ensures new instances take reduced traffic initially, reducing the risk of overload on cold-started services.

Why This Change?
Prevents sudden traffic spikes on new instances.
Helps in gracefully warming up services before full exposure.


