### PR TITLE
Added fallback in IdParsers.parse() for original formatter 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <groupId>io.appform.ranger</groupId>
     <artifactId>ranger</artifactId>
     <packaging>pom</packaging>
-    <version>1.1.0</version>
+    <version>1.1.1</version>
     <name>Ranger Service Discovery</name>
     <url>https://github.com/appform-io/ranger</url>
     <description>Service Discovery for Java</description>

--- a/ranger-bom/pom.xml
+++ b/ranger-bom/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.appform.ranger</groupId>
     <artifactId>ranger</artifactId>
-    <version>1.1.0</version>
+    <version>1.1.1</version>
   </parent>
 
   <artifactId>ranger-bom</artifactId>

--- a/ranger-client/pom.xml
+++ b/ranger-client/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>ranger</artifactId>
         <groupId>io.appform.ranger</groupId>
-        <version>1.1.0</version>
+        <version>1.1.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/ranger-core/pom.xml
+++ b/ranger-core/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>ranger</artifactId>
         <groupId>io.appform.ranger</groupId>
-        <version>1.1.0</version>
+        <version>1.1.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/ranger-discovery-bundle/perf/results/io.appform.ranger.discovery.bundle.id.IdGeneratorPerfTest.testGenerate.json
+++ b/ranger-discovery-bundle/perf/results/io.appform.ranger.discovery.bundle.id.IdGeneratorPerfTest.testGenerate.json
@@ -4,5 +4,5 @@
   "iterations" : 4,
   "threads" : 1,
   "forks" : 3,
-  "mean_ops" : 747058.7611573362
+  "mean_ops" : 983207.6911013111
 }

--- a/ranger-discovery-bundle/perf/results/io.appform.ranger.discovery.bundle.id.IdGeneratorPerfTest.testGenerateBase36.json
+++ b/ranger-discovery-bundle/perf/results/io.appform.ranger.discovery.bundle.id.IdGeneratorPerfTest.testGenerateBase36.json
@@ -4,5 +4,5 @@
   "iterations" : 4,
   "threads" : 1,
   "forks" : 3,
-  "mean_ops" : 549523.5120243506
+  "mean_ops" : 915820.4865429945
 }

--- a/ranger-discovery-bundle/pom.xml
+++ b/ranger-discovery-bundle/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>ranger</artifactId>
         <groupId>io.appform.ranger</groupId>
-        <version>1.1.0</version>
+        <version>1.1.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/ranger-discovery-bundle/src/main/java/io/appform/ranger/discovery/bundle/id/formatter/IdParsers.java
+++ b/ranger-discovery-bundle/src/main/java/io/appform/ranger/discovery/bundle/id/formatter/IdParsers.java
@@ -36,10 +36,46 @@ public class IdParsers {
     );
 
     /**
-     * Parse the given string to get ID
+     * Parses a string representation of an ID and converts it into an {@link Id} object.
      *
-     * @param idString String idString
-     * @return ID if it could be generated
+     * <p>This method attempts to parse the input string using a predefined regex pattern that expects
+     * the following format: {@code ([A-Za-z]*)([0-9]{22})([0-9]{2})?(.*)}</p>
+     *
+     * <p>The parsing process follows these steps:</p>
+     * <ol>
+     *   <li>Validates that the input string is not null and meets the minimum length requirement (22 characters)</li>
+     *   <li>Applies the regex pattern to extract components of the ID</li>
+     *   <li>Determines the appropriate formatter based on the parser type (group 3 of the regex)</li>
+     *   <li>If no parser type is found, defaults to the original formatter (Sample - T2407101232336168748798)</li>
+     *   <li>If an invalid parser type is found, logs a warning and falls back to the original formatter (Sample - 0M00002507241535374297496628)</li>
+     * </ol>
+     *
+     * <p>The method supports different ID formats through a registry of {@link IdFormatter} instances.
+     * Currently, the registry contains the original formatter for legacy ID formats.</p>
+     *
+     * <p><strong>Expected ID Format:</strong></p>
+     * <ul>
+     *   <li>Prefix: Optional alphabetic characters</li>
+     *   <li>Core ID: Exactly 22 numeric digits (required)</li>
+     *   <li>Parser Type: Optional 2-digit numeric formatter type identifier</li>
+     *   <li>Suffix: Optional additional characters</li>
+     * </ul>
+     *
+     * @param idString the string representation of the ID to parse. Must not be null and should be
+     *                 at least {@value #MINIMUM_ID_LENGTH} characters long to be considered valid
+     * @return an {@link Optional} containing the parsed {@link Id} if the string could be successfully
+     *         parsed and converted, or {@link Optional#empty()} if:
+     *         <ul>
+     *           <li>The input string is null</li>
+     *           <li>The input string is shorter than the minimum required length</li>
+     *           <li>The input string doesn't match the expected regex pattern</li>
+     *           <li>An exception occurs during parsing</li>
+     *         </ul>
+     *
+     * @see Id
+     * @see IdFormatter
+     * @see IdFormatters#original()
+     * @since 1.0
      */
     public Optional<Id> parse(final String idString) {
         if (idString == null || idString.length() < MINIMUM_ID_LENGTH) {
@@ -58,8 +94,8 @@ public class IdParsers {
 
             val parser = parserRegistry.get(Integer.parseInt(matcher.group(3)));
             if (parser == null) {
-                log.warn("Could not parse idString {}, Invalid formatter type {}", idString, parserType);
-                return Optional.empty();
+                log.warn("Could not parse idString {}, Invalid formatter type {}, Falling back to evaluate using default formatter (legacy format of ID)", idString, parserType);
+                return IdFormatters.original().parse(idString);
             }
             return parser.parse(idString);
         } catch (Exception e) {

--- a/ranger-discovery-bundle/src/test/java/io/appform/ranger/discovery/bundle/id/IdGeneratorTest.java
+++ b/ranger-discovery-bundle/src/test/java/io/appform/ranger/discovery/bundle/id/IdGeneratorTest.java
@@ -225,10 +225,16 @@ class IdGeneratorTest {
     }
 
     @Test
-    void testParseFailAfterGeneration() {
-        val generatedId = IdGenerator.generate("TEST123");
-        val parsedId = IdGenerator.parse(generatedId.getId()).orElse(null);
-        Assertions.assertNull(parsedId);
+    void testParseAnIdWithNonNumericPrefixUsingDefaultFormatter() {
+        val generatedId = "0M00002310011825377769658722";
+        val parsedId = IdGenerator.parse(generatedId).orElse(null);
+        Assertions.assertNotNull(parsedId);
+        val date = parsedId.getGeneratedDate();
+        Assertions.assertNotNull(date);
+        Assertions.assertEquals(722, parsedId.getExponent());
+        Assertions.assertEquals(9658, parsedId.getNode());
+        Assertions.assertEquals(generateDate(2023, 10, 1, 18, 25, 37, 777,
+                ZoneId.systemDefault()).toString(), date.toString());
     }
 
     @Test

--- a/ranger-discovery-bundle/src/test/java/io/appform/ranger/discovery/bundle/id/IdGeneratorTest.java
+++ b/ranger-discovery-bundle/src/test/java/io/appform/ranger/discovery/bundle/id/IdGeneratorTest.java
@@ -225,19 +225,6 @@ class IdGeneratorTest {
     }
 
     @Test
-    void testParseAnIdWithNonNumericPrefixUsingDefaultFormatter() {
-        val generatedId = "0M00002310011825377769658722";
-        val parsedId = IdGenerator.parse(generatedId).orElse(null);
-        Assertions.assertNotNull(parsedId);
-        val date = parsedId.getGeneratedDate();
-        Assertions.assertNotNull(date);
-        Assertions.assertEquals(722, parsedId.getExponent());
-        Assertions.assertEquals(9658, parsedId.getNode());
-        Assertions.assertEquals(generateDate(2023, 10, 1, 18, 25, 37, 777,
-                ZoneId.systemDefault()).toString(), date.toString());
-    }
-
-    @Test
     void testParseSuccessAfterGeneration() {
         val generatedId = IdGenerator.generate("TEST");
         val parsedId = IdGenerator.parse(generatedId.getId()).orElse(null);

--- a/ranger-discovery-bundle/src/test/java/io/appform/ranger/discovery/bundle/id/IdParsersTest.java
+++ b/ranger-discovery-bundle/src/test/java/io/appform/ranger/discovery/bundle/id/IdParsersTest.java
@@ -22,6 +22,17 @@ public class IdParsersTest {
         assertDate("240710123233616", parsedId.getGeneratedDate());
     }
 
+    @Test
+    void testDefaultIdWithNumericPrefix() throws ParseException {
+        val id = "0M00002507241535374297496628";
+        val parsedId = IdParsers.parse(id).orElse(null);
+        Assertions.assertNotNull(parsedId);
+        Assertions.assertEquals(id, parsedId.getId());
+        Assertions.assertEquals(628, parsedId.getExponent());
+        Assertions.assertEquals(7496, parsedId.getNode());
+        assertDate("250724153537429", parsedId.getGeneratedDate());
+    }
+
     private void assertDate(final String dateString, final Date date) throws ParseException {
         Assertions.assertEquals(new SimpleDateFormat("yyMMddHHmmssSSS").parse(dateString), date);
     }

--- a/ranger-drove-client/pom.xml
+++ b/ranger-drove-client/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>ranger</artifactId>
         <groupId>io.appform.ranger</groupId>
-        <version>1.1.0</version>
+        <version>1.1.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/ranger-drove/pom.xml
+++ b/ranger-drove/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>ranger</artifactId>
         <groupId>io.appform.ranger</groupId>
-        <version>1.1.0</version>
+        <version>1.1.1</version>
     </parent>
     <properties>
         <drove.version>1.30</drove.version>

--- a/ranger-http-client/pom.xml
+++ b/ranger-http-client/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>ranger</artifactId>
         <groupId>io.appform.ranger</groupId>
-        <version>1.1.0</version>
+        <version>1.1.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/ranger-http-model/pom.xml
+++ b/ranger-http-model/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>ranger</artifactId>
         <groupId>io.appform.ranger</groupId>
-        <version>1.1.0</version>
+        <version>1.1.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/ranger-http/pom.xml
+++ b/ranger-http/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>ranger</artifactId>
         <groupId>io.appform.ranger</groupId>
-        <version>1.1.0</version>
+        <version>1.1.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/ranger-hub-server-bundle/pom.xml
+++ b/ranger-hub-server-bundle/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>ranger</artifactId>
         <groupId>io.appform.ranger</groupId>
-        <version>1.1.0</version>
+        <version>1.1.1</version>
     </parent>
     <build>
         <plugins>

--- a/ranger-server-bundle/pom.xml
+++ b/ranger-server-bundle/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>ranger</artifactId>
         <groupId>io.appform.ranger</groupId>
-        <version>1.1.0</version>
+        <version>1.1.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/ranger-server-common/pom.xml
+++ b/ranger-server-common/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>ranger</artifactId>
         <groupId>io.appform.ranger</groupId>
-        <version>1.1.0</version>
+        <version>1.1.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/ranger-server/pom.xml
+++ b/ranger-server/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.appform.ranger</groupId>
         <artifactId>ranger</artifactId>
-        <version>1.1.0</version>
+        <version>1.1.1</version>
     </parent>
 
     <artifactId>ranger-server</artifactId>

--- a/ranger-zk-client/pom.xml
+++ b/ranger-zk-client/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>ranger</artifactId>
         <groupId>io.appform.ranger</groupId>
-        <version>1.1.0</version>
+        <version>1.1.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/ranger-zookeeper/pom.xml
+++ b/ranger-zookeeper/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>ranger</artifactId>
         <groupId>io.appform.ranger</groupId>
-        <version>1.1.0</version>
+        <version>1.1.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
This is done to accommodate for cases where prefix could potentially contain non-alphabetical digits (Sample - 0M00002507241535374297496628)