### PR TITLE
[Fix] Collision checker concurrent handling

### DIFF
--- a/ranger-discovery-bundle/src/main/java/io/appform/ranger/discovery/bundle/id/CollisionChecker.java
+++ b/ranger-discovery-bundle/src/main/java/io/appform/ranger/discovery/bundle/id/CollisionChecker.java
@@ -48,6 +48,12 @@ public class CollisionChecker {
         dataLock.lock();
         try {
             long resolvedTime = resolution.convert(timeInMillis, TimeUnit.MILLISECONDS);
+            // if currentInstant > resolvedTime then it means that bitset is already cleared for that particular resolvedTime
+            // which increases the chances of getting duplicated id generation
+            if (currentInstant > resolvedTime) {
+                return false;
+            }
+
             if (currentInstant != resolvedTime) {
                 currentInstant = resolvedTime;
                 bitSet.clear();


### PR DESCRIPTION
Issue in concurrent execution of collisionChecker
Example: 
Thread t1 get the time Xms, Just before the collisionChecker the clock moved to X+1ms
At the same time thread t2 with current time X+1ms started the collisionChecker, Thread t2 will update the currentInstant to X+1
When thread t1 will execute collisionChecker post t2 it will again reset the currentInstant to X, which will reset the bitset and ID collisions will happen for both X as well as X+1 bucket.

For eg -: Last Id = 0E2509151738525100023932
               Duplicated Id = 0E2509151738525080023432, This issue will occur if bitset is resetted