### PR TITLE
[Fix] Collision Check concurrency handling

### DIFF
--- a/ranger-discovery-bundle/src/main/java/io/appform/ranger/discovery/bundle/id/CollisionChecker.java
+++ b/ranger-discovery-bundle/src/main/java/io/appform/ranger/discovery/bundle/id/CollisionChecker.java
@@ -48,12 +48,12 @@ public class CollisionChecker {
         dataLock.lock();
         try {
             long resolvedTime = resolution.convert(timeInMillis, TimeUnit.MILLISECONDS);
-            if (currentInstant != resolvedTime) {
+            if (currentInstant < resolvedTime) {
                 currentInstant = resolvedTime;
                 bitSet.clear();
             }
 
-            if (bitSet.get(location)) {
+            if (currentInstant > resolvedTime || bitSet.get(location)) {
                 return false;
             }
             bitSet.set(location);


### PR DESCRIPTION
This PR fixes a concurrency bug that allowed duplicate IDs to be generated under high load. Previously, thread preemption could cause a delayed thread to enter CollisionChecker with a stale timestamp, erroneously clearing the BitSet and wiping the collision history for that millisecond.