### PR TITLE
Dependency version fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,8 +100,8 @@
         <guava-retrying.version>2.0.0</guava-retrying.version>
         <http.client.version>5.1.0</http.client.version>
         <dropwizard.version>2.1.12</dropwizard.version>
-        <logback.version>1.3.15</logback.version>
-        <jackson.version>2.20.0</jackson.version>
+        <logback.version>1.2.13</logback.version>
+        <kotlin.version>2.2.20</kotlin.version>
         <zookeeper.version>3.9.4</zookeeper.version>
         <!-- Test Dependencies -->
         <wiremock.version>3.3.1</wiremock.version>
@@ -153,20 +153,6 @@
                 <scope>import</scope>
             </dependency>
             <dependency>
-                <groupId>com.fasterxml.jackson</groupId>
-                <artifactId>jackson-bom</artifactId>
-                <version>${jackson.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>ch.qos.logback</groupId>
-                <artifactId>logback-parent</artifactId>
-                <version>${logback.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
                 <groupId>com.squareup.okhttp3</groupId>
                 <artifactId>okhttp-bom</artifactId>
                 <version>${http.client.version}</version>
@@ -202,6 +188,26 @@
                 <groupId>org.apache.zookeeper</groupId>
                 <artifactId>zookeeper</artifactId>
                 <version>${zookeeper.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.slf4j</groupId>
+                        <artifactId>slf4j-log4j12</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>log4j</groupId>
+                        <artifactId>log4j</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-stdlib</artifactId>
+                <version>${kotlin.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-stdlib-common</artifactId>
+                <version>${kotlin.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.xmlunit</groupId>

--- a/ranger-discovery-bundle/perf/results/io.appform.ranger.discovery.bundle.id.IdGeneratorPerfTest.testGenerate.json
+++ b/ranger-discovery-bundle/perf/results/io.appform.ranger.discovery.bundle.id.IdGeneratorPerfTest.testGenerate.json
@@ -4,5 +4,5 @@
   "iterations" : 4,
   "threads" : 1,
   "forks" : 3,
-  "mean_ops" : 874743.1579406814
+  "mean_ops" : 878556.2793906716
 }

--- a/ranger-discovery-bundle/perf/results/io.appform.ranger.discovery.bundle.id.IdGeneratorPerfTest.testGenerate.json
+++ b/ranger-discovery-bundle/perf/results/io.appform.ranger.discovery.bundle.id.IdGeneratorPerfTest.testGenerate.json
@@ -4,5 +4,5 @@
   "iterations" : 4,
   "threads" : 1,
   "forks" : 3,
-  "mean_ops" : 822999.279346419
+  "mean_ops" : 874743.1579406814
 }

--- a/ranger-discovery-bundle/perf/results/io.appform.ranger.discovery.bundle.id.IdGeneratorPerfV2Test.testGenerateBase36Id.json
+++ b/ranger-discovery-bundle/perf/results/io.appform.ranger.discovery.bundle.id.IdGeneratorPerfV2Test.testGenerateBase36Id.json
@@ -4,5 +4,5 @@
   "iterations" : 4,
   "threads" : 1,
   "forks" : 3,
-  "mean_ops" : 433515.87378040206
+  "mean_ops" : 454741.0704572864
 }

--- a/ranger-discovery-bundle/perf/results/io.appform.ranger.discovery.bundle.id.IdGeneratorPerfV2Test.testGenerateSuffixedId.json
+++ b/ranger-discovery-bundle/perf/results/io.appform.ranger.discovery.bundle.id.IdGeneratorPerfV2Test.testGenerateSuffixedId.json
@@ -4,5 +4,5 @@
   "iterations" : 4,
   "threads" : 1,
   "forks" : 3,
-  "mean_ops" : 529535.7742132996
+  "mean_ops" : 518975.01737692434
 }


### PR DESCRIPTION
With current dependenies we are  facing error at startup. These are the dependnecy causing issues.
Issue 1: Logback 1.2.13 → 1.3.15
Issue 2: Jackson 2.13.x → 2.20.0 (dataformat-yaml)
Issue 3: Jackson 2.13.x → 2.20.0 (module-blackbird)
Issue 4: Kotlin 1.4.10 vs OkIO 3.16.2
Issue 5: SLF4J/Log4j circular delegation

