### PR TITLE
Fix ServiceFinderHub duplicate refresh signal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,7 @@ out
 dep
 .java-version
 stage.yml
+*.project
+*.settings
+*.classpath
+*.factorypath

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <groupId>io.appform.ranger</groupId>
     <artifactId>ranger</artifactId>
     <packaging>pom</packaging>
-    <version>2.0.0-RC5</version>
+    <version>2.0.1-RC5</version>
     <name>Ranger Service Discovery</name>
     <url>https://github.com/appform-io/ranger</url>
     <description>Service Discovery for Java</description>

--- a/ranger-bom/pom.xml
+++ b/ranger-bom/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.appform.ranger</groupId>
     <artifactId>ranger</artifactId>
-    <version>2.0.0-RC5</version>
+    <version>2.0.1-RC5</version>
   </parent>
 
   <artifactId>ranger-bom</artifactId>

--- a/ranger-client/pom.xml
+++ b/ranger-client/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>ranger-parent</artifactId>
         <groupId>io.appform.ranger</groupId>
-        <version>2.0.0-RC5</version>
+        <version>2.0.1-RC5</version>
         <relativePath>../ranger-parent</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/ranger-core/pom.xml
+++ b/ranger-core/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>ranger-parent</artifactId>
         <groupId>io.appform.ranger</groupId>
-        <version>2.0.0-RC5</version>
+        <version>2.0.1-RC5</version>
         <relativePath>../ranger-parent</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/ranger-core/src/main/java/io/appform/ranger/core/finderhub/ServiceFinderHub.java
+++ b/ranger-core/src/main/java/io/appform/ranger/core/finderhub/ServiceFinderHub.java
@@ -77,6 +77,7 @@ public class ServiceFinderHub<T, R extends ServiceRegistry<T>> {
     private final ExternalTriggeredSignal<Void> stopSignal
             = new ExternalTriggeredSignal<>(() -> null, Collections.emptyList());
 
+    @Getter
     private final List<Signal<Void>> refreshSignals = new ArrayList<>();
 
     @Getter
@@ -107,14 +108,24 @@ public class ServiceFinderHub<T, R extends ServiceRegistry<T>> {
             long serviceRefreshTimeoutMs,
             long hubStartTimeoutMs,
             final Set<String> excludedServices) {
+         this(serviceDataSource, finderFactory, serviceRefreshTimeoutMs, hubStartTimeoutMs, HubConstants.REFRESH_FREQUENCY_MS, excludedServices);
+    }
+
+    public ServiceFinderHub(
+            ServiceDataSource serviceDataSource,
+            ServiceFinderFactory<T, R> finderFactory,
+            long serviceRefreshTimeoutMs,
+            long hubStartTimeoutMs,
+            long refreshFrequencyMs,
+            final Set<String> excludedServices) {
         this.serviceDataSource = serviceDataSource;
         this.finderFactory = finderFactory;
         this.serviceRefreshTimeoutMs = serviceRefreshTimeoutMs == 0 ? HubConstants.SERVICE_REFRESH_TIMEOUT_MS : serviceRefreshTimeoutMs;
         this.hubStartTimeoutMs = hubStartTimeoutMs == 0 ? HubConstants.HUB_START_TIMEOUT_MS : hubStartTimeoutMs;
-        this.refreshSignals.add(new ScheduledSignal<>("service-hub-updater",
-                                                      () -> null,
-                                                      Collections.emptyList(),
-                                      10_000));
+        this.refreshSignals.add(new ScheduledSignal<>("service-hub-refresh-timer",
+                () -> null,
+                Collections.emptyList(),
+                refreshFrequencyMs));
         this.refresherPool = createRefresherPool();
         this.excludedServices = Objects.requireNonNullElseGet(excludedServices, Set::of);
     }

--- a/ranger-core/src/main/java/io/appform/ranger/core/finderhub/ServiceFinderHubBuilder.java
+++ b/ranger-core/src/main/java/io/appform/ranger/core/finderhub/ServiceFinderHubBuilder.java
@@ -98,21 +98,16 @@ public abstract class ServiceFinderHubBuilder<T, R extends ServiceRegistry<T>> {
         requireNonNull(serviceFinderFactory, "Provide a non-null service finder factory");
 
         val hub = new ServiceFinderHub<>(serviceDataSource, serviceFinderFactory, serviceRefreshTimeoutMs,
-                hubStartTimeoutMs, excludedServices);
-        final ScheduledSignal<Void> refreshSignal = new ScheduledSignal<>("service-hub-refresh-timer",
-                                                                          () -> null,
-                                                                          Collections.emptyList(),
-                                                                          refreshFrequencyMs);
-        hub.registerUpdateSignal(refreshSignal);
+                hubStartTimeoutMs, refreshFrequencyMs, excludedServices);
         extraRefreshSignals.forEach(hub::registerUpdateSignal);
 
         hub.getStartSignal()
                 .registerConsumer(x -> serviceDataSource.start())
-                .registerConsumer(x -> refreshSignal.start())
+                .registerConsumers(hub.getRefreshSignals().stream().map(rs -> (Consumer<Void>) x -> rs.start()).toList())
                 .registerConsumers(extraStartSignalConsumers);
         hub.getStopSignal()
                 .registerConsumers(extraStopSignalConsumers)
-                .registerConsumer(x -> refreshSignal.stop())
+                .registerConsumers(hub.getRefreshSignals().stream().map(rs -> (Consumer<Void>) x -> rs.stop()).toList())
                 .registerConsumer(x -> serviceDataSource.stop());
         postBuild(hub);
         return hub;

--- a/ranger-discovery-bundle/pom.xml
+++ b/ranger-discovery-bundle/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>ranger-parent</artifactId>
         <groupId>io.appform.ranger</groupId>
-        <version>2.0.0-RC5</version>
+        <version>2.0.1-RC5</version>
         <relativePath>../ranger-parent</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/ranger-discovery-core/pom.xml
+++ b/ranger-discovery-core/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>ranger-parent</artifactId>
         <groupId>io.appform.ranger</groupId>
-        <version>2.0.0-RC5</version>
+        <version>2.0.1-RC5</version>
         <relativePath>../ranger-parent</relativePath>
     </parent>
 

--- a/ranger-discovery-dw5-bundle/pom.xml
+++ b/ranger-discovery-dw5-bundle/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>ranger-parent</artifactId>
         <groupId>io.appform.ranger</groupId>
-        <version>2.0.0-RC5</version>
+        <version>2.0.1-RC5</version>
         <relativePath>../ranger-parent</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/ranger-drove-client/pom.xml
+++ b/ranger-drove-client/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>ranger-parent</artifactId>
         <groupId>io.appform.ranger</groupId>
-        <version>2.0.0-RC5</version>
+        <version>2.0.1-RC5</version>
         <relativePath>../ranger-parent</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/ranger-drove/pom.xml
+++ b/ranger-drove/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>ranger-parent</artifactId>
         <groupId>io.appform.ranger</groupId>
-        <version>2.0.0-RC5</version>
+        <version>2.0.1-RC5</version>
         <relativePath>../ranger-parent</relativePath>
     </parent>
     <properties>

--- a/ranger-http-client/pom.xml
+++ b/ranger-http-client/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>ranger-parent</artifactId>
         <groupId>io.appform.ranger</groupId>
-        <version>2.0.0-RC5</version>
+        <version>2.0.1-RC5</version>
         <relativePath>../ranger-parent</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/ranger-http-model/pom.xml
+++ b/ranger-http-model/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>ranger-parent</artifactId>
         <groupId>io.appform.ranger</groupId>
-        <version>2.0.0-RC5</version>
+        <version>2.0.1-RC5</version>
         <relativePath>../ranger-parent</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/ranger-http/pom.xml
+++ b/ranger-http/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>ranger-parent</artifactId>
         <groupId>io.appform.ranger</groupId>
-        <version>2.0.0-RC5</version>
+        <version>2.0.1-RC5</version>
         <relativePath>../ranger-parent</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/ranger-hub-server-bundle-core/pom.xml
+++ b/ranger-hub-server-bundle-core/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>ranger-parent</artifactId>
         <groupId>io.appform.ranger</groupId>
-        <version>2.0.0-RC5</version>
+        <version>2.0.1-RC5</version>
         <relativePath>../ranger-parent</relativePath>
     </parent>
     <properties>

--- a/ranger-hub-server-bundle/pom.xml
+++ b/ranger-hub-server-bundle/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>ranger-parent</artifactId>
         <groupId>io.appform.ranger</groupId>
-        <version>2.0.0-RC5</version>
+        <version>2.0.1-RC5</version>
         <relativePath>../ranger-parent</relativePath>
     </parent>
     <build>

--- a/ranger-hub-server-dw5-bundle/pom.xml
+++ b/ranger-hub-server-dw5-bundle/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>ranger-parent</artifactId>
         <groupId>io.appform.ranger</groupId>
-        <version>2.0.0-RC5</version>
+        <version>2.0.1-RC5</version>
         <relativePath>../ranger-parent</relativePath>
     </parent>
 

--- a/ranger-id/pom.xml
+++ b/ranger-id/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>ranger-parent</artifactId>
         <groupId>io.appform.ranger</groupId>
-        <version>2.0.0-RC5</version>
+        <version>2.0.1-RC5</version>
         <relativePath>../ranger-parent</relativePath>
     </parent>
 

--- a/ranger-parent/pom.xml
+++ b/ranger-parent/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.appform.ranger</groupId>
         <artifactId>ranger</artifactId>
-        <version>2.0.0-RC5</version>
+        <version>2.0.1-RC5</version>
     </parent>
 
     <artifactId>ranger-parent</artifactId>

--- a/ranger-reporting/pom.xml
+++ b/ranger-reporting/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>ranger-parent</artifactId>
         <groupId>io.appform.ranger</groupId>
-        <version>2.0.0-RC5</version>
+        <version>2.0.1-RC5</version>
         <relativePath>../ranger-parent</relativePath>
     </parent>
 

--- a/ranger-server-bundle/pom.xml
+++ b/ranger-server-bundle/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>ranger-parent</artifactId>
         <groupId>io.appform.ranger</groupId>
-        <version>2.0.0-RC5</version>
+        <version>2.0.1-RC5</version>
         <relativePath>../ranger-parent</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/ranger-server-common/pom.xml
+++ b/ranger-server-common/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>ranger-parent</artifactId>
         <groupId>io.appform.ranger</groupId>
-        <version>2.0.0-RC5</version>
+        <version>2.0.1-RC5</version>
         <relativePath>../ranger-parent</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/ranger-server-dw5-bundle/pom.xml
+++ b/ranger-server-dw5-bundle/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>ranger-parent</artifactId>
         <groupId>io.appform.ranger</groupId>
-        <version>2.0.0-RC5</version>
+        <version>2.0.1-RC5</version>
         <relativePath>../ranger-parent</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/ranger-server/pom.xml
+++ b/ranger-server/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>ranger-parent</artifactId>
         <groupId>io.appform.ranger</groupId>
-        <version>2.0.0-RC5</version>
+        <version>2.0.1-RC5</version>
         <relativePath>../ranger-parent</relativePath>
     </parent>
 

--- a/ranger-zk-client/pom.xml
+++ b/ranger-zk-client/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>ranger-parent</artifactId>
         <groupId>io.appform.ranger</groupId>
-        <version>2.0.0-RC5</version>
+        <version>2.0.1-RC5</version>
         <relativePath>../ranger-parent</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/ranger-zookeeper/pom.xml
+++ b/ranger-zookeeper/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>ranger-parent</artifactId>
         <groupId>io.appform.ranger</groupId>
-        <version>2.0.0-RC5</version>
+        <version>2.0.1-RC5</version>
         <relativePath>../ranger-parent</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>


### PR DESCRIPTION
**Issue**: The refresh timer was being created in two places — once inside ServiceFinderHub (hardcoded to 10s) and once in ServiceFinderHubBuilder. The builder's configurable refreshFrequencyMs was never actually used by the hub's internal timer, and lifecycle (start/stop) wiring was fragile.

**Fix**: Moved the refresh timer creation entirely into ServiceFinderHub, accepting refreshFrequencyMs as a constructor parameter. The builder now just passes the value through and generically wires start/stop for all refresh signals. Single source of truth, no duplication.